### PR TITLE
mobile keyboard - fixed inconsistent predicate logic translation detection

### DIFF
--- a/src/components/problems/mui/SymbolicTranslation.jsx
+++ b/src/components/problems/mui/SymbolicTranslation.jsx
@@ -36,6 +36,12 @@ function isPredicateLogicKey(symbolizationKey) {
   })
 }
 
+function promptImpliesPredicateLogic(promptText) {
+  const prompt = typeof promptText === 'string' ? promptText : String(promptText ?? '')
+  const text = prompt.replace(/<[^>]+>/g, ' ').toLowerCase()
+  return /\bpredicate logic\b/.test(text)
+}
+
 function getPredicateLettersFromKey(symbolizationKey) {
   if (!Array.isArray(symbolizationKey) || symbolizationKey.length === 0) return []
   const seen = new Set()
@@ -226,13 +232,15 @@ export default function SymbolicTranslation({
       ? symbolizationKeyRaw.split('\n').map((line) => line.trim()).filter(Boolean)
       : [])
 
-  const isPredicate = isPredicateLogicKey(symbolizationKey)
+  const isPredicate = isPredicateLogicKey(symbolizationKey) || promptImpliesPredicateLogic(prompt)
   const predicateLetters = isPredicate ? getPredicateLettersFromKey(symbolizationKey) : []
   const constantsFromKey = getConstantLettersFromKey(symbolizationKey)
   const constantLetters = isPredicate
     ? (constantsFromKey.length > 0
         ? constantsFromKey
-        : getConstantLettersFromPromptAndKey(prompt, symbolizationKey, 3))
+        : (symbolizationKey.length === 0
+            ? getConstantLettersFromPromptAndKey(prompt, symbolizationKey, 3)
+            : []))
     : []
   const variableLetters = isPredicate ? ST_PREDICATE_VARIABLES : []
 

--- a/src/components/ui/LogicKeyboard/MobileLogicInput.jsx
+++ b/src/components/ui/LogicKeyboard/MobileLogicInput.jsx
@@ -24,7 +24,8 @@ function getVariableLettersOnly(symbolizationKey) {
   const letters = symbolizationKey
     .map((line) => {
       const s = typeof line === 'string' ? line : String(line ?? '')
-      const symbol = s.split('=')[0].trim()
+      const splitAt = s.search(/[=:]/)
+      const symbol = (splitAt === -1 ? s : s.slice(0, splitAt)).trim()
       return symbol || null
     })
     .filter(Boolean)


### PR DESCRIPTION
## 📝 Description

The issue was inconsistent predicate-keyboard detection in `SymbolicTranslation`:
- Some predicate questions (like 8.1(2)/(3)) had keys such as `D: is a dragon` (single uppercase + `:`), which our old logic misclassified as *propositional*.
- Also, the fallback key parser in `MobileLogicInput` only split on `=`, so `D: is a dragon` could render as a whole button label instead of just `D`.

This PR does the following:
- In `SymbolicTranslation`, predicate mode now also activates when the prompt clearly says *“predicate logic”*.
- For predicate mode, constants now come from the key only; if the key exists but has no lowercase constants, we show no constants (instead of inventing `a,b,c`).
- In `MobileLogicInput`, key parsing now splits on both `:` and `=`, so labels like `D: ...` correctly become `D`.

## 🚀 Type of Change

- [X] 🐛 Bug fix

## 🧪 How to Test

In Predicate Logic Translation questions that have only one capital letter symbol, ensure that the mobile keyboard is correctly displaying the predicate keyboard layout.

Assignments 8.1 (2) and 8.1 (3) have several testable questions.

All other layouts should remain unchanged.

## ✅ Pre-Merge Checklist

- [X] I have performed a self-review of my own code.
- [X] I have removed all temporary `console.log`s and debuggers.
- [X] I have successfully rebased / resolved any merge conflicts with `main`.
- [X] UI looks good on both desktop and mobile viewports.
