### PR TITLE
Fix CP and IP correctness

### DIFF
--- a/src/components/problems/derivation/DerivationTable.jsx
+++ b/src/components/problems/derivation/DerivationTable.jsx
@@ -37,6 +37,7 @@ import getFormulaClass from '../../../lib/logicpenguin/symbolic/formula.js'
 import getSyntax from '../../../lib/logicpenguin/symbolic/libsyntax.js'
 import { justParse } from '../../ui/logicpenguin/justification-parse.js'
 import { getInsertSymbolLabel } from '../../ui/logicpenguin/LogicSymbol.jsx'
+import { getOpenAssumptionDepths, isResolvedConclusionLine } from './derivationUtils.js'
 
 /** Compare formula strings by canonical form so ∃x(~Hx) and ∃x~Hx count equal */
 function formulasEqualNormally(a, b, normalizeForFallback) {
@@ -638,11 +639,19 @@ export default function DerivationTable({
     const lastFilledIndex = filledLineIndices.length ? filledLineIndices[filledLineIndices.length - 1] : -1
     const lastFilled = lastFilledIndex >= 0 ? linesSnapshot[lastFilledIndex] : null
     const allFilledComplete = filledLineIndices.every((idx) => isLineComplete(idx))
+    const openAssumptionDepths = getOpenAssumptionDepths(linesSnapshot)
+    const lastFilledResolvesConclusion = isResolvedConclusionLine({
+      line: lastFilled,
+      index: lastFilledIndex,
+      conclusion: proof?.conclusion,
+      normalizeFormula: normalizeFormulaForCheck,
+      openAssumptionDepths,
+    })
     const readyForRuleGate = Boolean(
       normalizedConclusion &&
       lastFilled &&
       isLineCompleteForCheck(lastFilled) &&
-      formulasEqualNormally(lastFilled.formula || '', proof?.conclusion || '', normalizeFormulaForCheck) &&
+      lastFilledResolvesConclusion &&
       allFilledComplete
     )
     const filteredErrors = {}
@@ -708,7 +717,13 @@ export default function DerivationTable({
       !last.readOnly &&
       isLineCompleteForCheck(last) &&
       perLine[lastIndex] === 'ok' &&
-      !formulasEqualNormally(last.formula || '', proof?.conclusion || '', normalizeFormulaForCheck)
+      !isResolvedConclusionLine({
+        line: last,
+        index: lastIndex,
+        conclusion: proof?.conclusion,
+        normalizeFormula: normalizeFormulaForCheck,
+        openAssumptionDepths,
+      })
     )
     return { perLine, rows, shouldAutoAdd }
   }, [normalizeFormulaForCheck, normalizeJustificationForCheck, premises, proof?.conclusion, proof?.options, proof?.ruleset, isLineCompleteForCheck])
@@ -732,7 +747,14 @@ export default function DerivationTable({
             if (!last || last.readOnly || !isLineCompleteForCheck(last)) return prev
             const conclusionStr = proof?.conclusion || ''
             if (!conclusionStr) return prev
-            if (formulasEqualNormally(last.formula || '', conclusionStr, normalizeFormulaForCheck)) return prev
+            const openAssumptionDepths = getOpenAssumptionDepths(prev)
+            if (isResolvedConclusionLine({
+              line: last,
+              index: prev.length - 1,
+              conclusion: conclusionStr,
+              normalizeFormula: normalizeFormulaForCheck,
+              openAssumptionDepths,
+            })) return prev
             pendingFocusRef.current = prev.length
             return [...prev, { formula: '', justification: '', readOnly: false }]
           })
@@ -770,12 +792,14 @@ export default function DerivationTable({
     if (!lastFilled || lastFilled.readOnly) return { ok: false, index: null }
     if (!isLineCompleteForCheck(lastFilled)) return { ok: false, index: null }
     if (autoCheckState.perLine[lastFilledIndex] !== 'ok') return { ok: false, index: null }
-    const matchesConclusion = formulasEqualNormally(
-      lastFilled.formula || '',
+    const openAssumptionDepths = getOpenAssumptionDepths(lines)
+    if (!isResolvedConclusionLine({
+      line: lastFilled,
+      index: lastFilledIndex,
       conclusion,
-      normalizeFormulaForCheck
-    )
-    if (!matchesConclusion) return { ok: false, index: null }
+      normalizeFormula: normalizeFormulaForCheck,
+      openAssumptionDepths,
+    })) return { ok: false, index: null }
     return { ok: true, index: lastFilledIndex }
   }, [autoCheckEnabled, autoCheckState.perLine, isLineCompleteForCheck, lines, normalizeFormulaForCheck, premises.length, proof?.conclusion])
 

--- a/src/components/problems/derivation/derivationUtils.js
+++ b/src/components/problems/derivation/derivationUtils.js
@@ -250,6 +250,34 @@ export const getRuleFromJustification = (value) => {
   return formatRuleName(citedrules[0])
 }
 
+export const getOpenAssumptionDepths = (linesSnapshot = []) => {
+  let depth = 0
+  return linesSnapshot.map((line) => {
+    const rule = getRuleFromJustification(line?.justification || '').toUpperCase()
+    // cp and ip close before their own line lands
+    if (INDENT_END_RULES.has(rule)) {
+      depth = Math.max(0, depth - 1)
+    }
+    if (INDENT_START_RULES.has(rule)) {
+      depth = Math.min(depth + 1, MAX_INDENT_LEVEL)
+    }
+    return depth
+  })
+}
+
+export const isResolvedConclusionLine = ({
+  line,
+  index,
+  conclusion,
+  normalizeFormula,
+  openAssumptionDepths,
+}) => {
+  if (!line || !String(conclusion || '').trim() || !Number.isInteger(index)) return false
+  if (!formulasEqualNormally(line.formula || '', conclusion, normalizeFormula)) return false
+  // a matching formula inside an open assumption does not end the proof
+  return (openAssumptionDepths?.[index] ?? 0) === 0
+}
+
 export const buildErrorRows = (errors, linesSnapshot = [], { skipCompletion = false } = {}) => {
   if (!errors) return []
   const lines = Object.keys(errors).sort((a, b) => {

--- a/src/components/problems/derivation/derivationWorkflow.js
+++ b/src/components/problems/derivation/derivationWorkflow.js
@@ -6,8 +6,10 @@ import {
   buildErrorRows,
   buildSubmission,
   formulasEqualNormally,
+  getOpenAssumptionDepths,
   getJustificationMeta,
   getRuleFromJustification,
+  isResolvedConclusionLine,
 } from './derivationUtils.js'
 
 export async function runDerivationAutoCheck({
@@ -47,11 +49,19 @@ export async function runDerivationAutoCheck({
   const lastFilledIndex = filledLineIndices.length ? filledLineIndices[filledLineIndices.length - 1] : -1
   const lastFilled = lastFilledIndex >= 0 ? linesSnapshot[lastFilledIndex] : null
   const allFilledComplete = filledLineIndices.every((index) => isLineComplete(index))
+  const openAssumptionDepths = getOpenAssumptionDepths(linesSnapshot)
+  const lastFilledResolvesConclusion = isResolvedConclusionLine({
+    line: lastFilled,
+    index: lastFilledIndex,
+    conclusion: proof?.conclusion,
+    normalizeFormula: normalizeFormulaForCheck,
+    openAssumptionDepths,
+  })
   const readyForRuleGate = Boolean(
     normalizedConclusion &&
     lastFilled &&
     isLineCompleteForCheck(lastFilled) &&
-    formulasEqualNormally(lastFilled.formula || '', proof?.conclusion || '', normalizeFormulaForCheck) &&
+    lastFilledResolvesConclusion &&
     allFilledComplete
   )
   const filteredErrors = {}
@@ -110,7 +120,13 @@ export async function runDerivationAutoCheck({
     !last.readOnly &&
     isLineCompleteForCheck(last) &&
     perLine[lastIndex] === 'ok' &&
-    !formulasEqualNormally(last.formula || '', proof?.conclusion || '', normalizeFormulaForCheck)
+    !isResolvedConclusionLine({
+      line: last,
+      index: lastIndex,
+      conclusion: proof?.conclusion,
+      normalizeFormula: normalizeFormulaForCheck,
+      openAssumptionDepths,
+    })
   )
   return { perLine, rows, shouldAutoAdd }
 }
@@ -140,12 +156,14 @@ export function deriveDerivationLooksGood({
   if (!lastFilled || lastFilled.readOnly) return { ok: false, index: null }
   if (!isLineCompleteForCheck(lastFilled)) return { ok: false, index: null }
   if (autoCheckPerLine[lastFilledIndex] !== 'ok') return { ok: false, index: null }
-  const matchesConclusion = formulasEqualNormally(
-    lastFilled.formula || '',
+  const openAssumptionDepths = getOpenAssumptionDepths(lines)
+  if (!isResolvedConclusionLine({
+    line: lastFilled,
+    index: lastFilledIndex,
     conclusion,
-    normalizeFormulaForCheck
-  )
-  if (!matchesConclusion) return { ok: false, index: null }
+    normalizeFormula: normalizeFormulaForCheck,
+    openAssumptionDepths,
+  })) return { ok: false, index: null }
   return { ok: true, index: lastFilledIndex }
 }
 

--- a/src/lib/logicpenguin/checkers/derivation-check.js
+++ b/src/lib/logicpenguin/checkers/derivation-check.js
@@ -165,13 +165,37 @@ export default class DerivationCheck {
 
     checkConc() {
         const Formula = this.Formula;
+        let hasMainScopeConclusion = false;
+        let lastSubstantiveLine = null;
         for (const line of (this.deriv.lines ?? [])) {
             if (!line) { continue; }
+            if ((line.s && line.s.trim()) || (line.j && line.j.trim())) {
+                lastSubstantiveLine = line;
+            }
             const lineNorm = line.formulaNormal ??
                 (line.s ? Formula.from(line.s).normal : '');
-            if (lineNorm == this.conc) {
-                return;
+            const openAssumptions = Array.isArray(line?.openAssumptions)
+                ? line.openAssumptions
+                : [];
+            // only a conclusion in the main proof scope can finish the proof
+            if (lineNorm === this.conc && openAssumptions.length === 0) {
+                hasMainScopeConclusion = true;
             }
+        }
+        const unresolvedAssumptions = Array.isArray(lastSubstantiveLine?.openAssumptions)
+            ? lastSubstantiveLine.openAssumptions
+            : [];
+        // the last real line tells us whether an acp or aip is still open
+        if (unresolvedAssumptions.length > 0) {
+            this.adderror(
+                lastSubstantiveLine?.n || '1',
+                "completion",
+                "high",
+                "open ACP/AIP subderivations must be closed with CP/IP before the proof is complete"
+            );
+        }
+        if (hasMainScopeConclusion) {
+            return;
         }
         
         // we attach the error to line one, which we really shouldn't but

--- a/src/lib/logicpenguin/checkers/derivation-check.js
+++ b/src/lib/logicpenguin/checkers/derivation-check.js
@@ -187,6 +187,27 @@ export default class DerivationCheck {
             : [];
         // the last real line tells us whether an acp or aip is still open
         if (unresolvedAssumptions.length > 0) {
+            const unresolvedRules = new Set(
+                unresolvedAssumptions.map((assumptionLine) =>
+                    this.resolveRuleName(assumptionLine)
+                )
+            );
+            if (unresolvedRules.has('ACP')) {
+                this.adderror(
+                    lastSubstantiveLine?.n || '1',
+                    "dependency",
+                    "low",
+                    "Conditional Proof sequence not discharged."
+                );
+            }
+            if (unresolvedRules.has('AIP')) {
+                this.adderror(
+                    lastSubstantiveLine?.n || '1',
+                    "dependency",
+                    "low",
+                    "Indirect Proof sequence not discharged."
+                );
+            }
             this.adderror(
                 lastSubstantiveLine?.n || '1',
                 "completion",


### PR DESCRIPTION
## 🔗 Linked Issue

Closes #18 

## 📝 Description

The derivation checker forces the conclusion to appear in the main proof scope, not inside an open ACP or AIP sequence.
- Added unresolved sequence feedback:
  - `Conditional Proof sequence not discharged.`
  - `Indirect Proof sequence not discharged.`
- Updated frontend derivation gating so line creation and completion status do not stop early when the conclusion is reached inside an open ACP or AIP sequence 

## 🚀 Type of Change

- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 🛠️ Refactor / Chore (Code cleanup, dependency update, etc.)

## 🧪 How to Test
1. Pull down this branch and run `npm run dev`
2. Navigate to any derivation question
3. Start a derivation with ACP or AIP
4. Check for a warning message
5.  Derive the target conclusion inside that open sequence
6. Do not discharge/use CP or IP
7. Verify that a warning appears:
   - `Conditional Proof sequence not discharged.` or
   - `Indirect Proof sequence not discharged.`
8. Verify that the answer is marked incorrect
9. Then properly discharge the sequence with CP or IP
10. Verify that the warning clears and the completed proof can be marked correct

  Example:
  - Premise: `A ⊃ P`
  - Conclusion: `(A • B) ⊃ (P ∨ Q)`
  
  Entered derivation:
  
  1. `A ⊃ P`
  2. `A • B` ACP
  3. `A` 2 Simp
  4. `P` 1,3 MP
  9. `P ∨ Q` 4 Add
  12. `(A • B) ⊃ (P ∨ Q)` ACP

The answer should be marked incorrect until the open ACP or AIP is properly discharged with CP or IP. While the ACP sequence is open, the checker should issue a warning. 

## ✅ Pre-Merge Checklist

- [x] I have performed a self-review of my own code.
- [x] I have removed all temporary `console.log`s and debuggers.
- [x] I have successfully rebased / resolved any merge conflicts with `main`.
- [x] UI looks good on both desktop and mobile viewports.
