### PR TITLE
Assignment layout

### DIFF
--- a/src/components/problems/ProofTabs.jsx
+++ b/src/components/problems/ProofTabs.jsx
@@ -35,9 +35,9 @@ function TabPanel(props) {
         <Box 
           sx={{ 
             // let page scroll
-            pl: { xs: 0, md: 3 }, 
-            pr: { xs: 0, md: 3 }, 
-            pt: { xs: 2, md: 0 }, 
+            pl: { xs: 0, md: 5, lg: 7, xl: 9 },
+            pr: { xs: 0, md: 5, lg: 7, xl: 9 },
+            pt: { xs: 2, md: 1 },
             pb: 0, 
             overflowX: 'auto',
             overflowY: 'visible',
@@ -258,7 +258,7 @@ function ProofTabs({
   React.useEffect(() => {
     prevIndexRef.current = currentProofIndex
   }, [currentProofIndex])
-  
+
   return (
     <Box sx={{ flexGrow: 1, display: 'flex', flexDirection: { xs: 'column', md: 'row' }, mt: 0, minWidth: 0, maxWidth: '100%' }}>
       <Box sx={{ 

--- a/src/components/ui/ActivityAccordion.jsx
+++ b/src/components/ui/ActivityAccordion.jsx
@@ -23,6 +23,7 @@ export default function ActivityAccordion({
   showExpandCollapseToggle = false,
   isLoading = false,
   defaultExpanded = true,
+  defaultSubchapterExpanded = defaultExpanded,
   persistKey = null,
 }) {
   const [expandedChapters, setExpandedChapters] = useState({})
@@ -102,7 +103,8 @@ export default function ActivityAccordion({
   }
 
   const isChapterExpandedById = (chapterId) => expandedChapters[chapterId] ?? defaultExpanded
-  const isSubchapterExpandedById = (subchapterId) => expandedSubchapters[subchapterId] ?? defaultExpanded
+  const isSubchapterExpandedById = (subchapterId) =>
+    expandedSubchapters[subchapterId] ?? defaultSubchapterExpanded
   const isAnyCollapsed = courseStructure.some((chapter) => {
     if (!isChapterExpandedById(chapter.id)) return true
     return chapter.subchapters.some((subchapter) => !isSubchapterExpandedById(subchapter.id))

--- a/src/components/ui/ActivityAccordion.jsx
+++ b/src/components/ui/ActivityAccordion.jsx
@@ -282,64 +282,71 @@ export default function ActivityAccordion({
                         sx={{
                           flexDirection: 'column',
                           alignItems: 'stretch',
-                          borderBottom: '1px solid',
-                          borderColor: 'divider',
-                          '&:last-child': {
-                            borderBottom: 'none',
+                          '&:not(:last-child) .subchapter-shell': {
+                            borderBottom: '1px solid',
+                            borderColor: 'divider',
                           },
                         }}
                       >
-                        <Accordion
-                          expanded={isSubchapterExpanded}
-                          onChange={handleSubchapterChange(subchapter.id)}
-                          elevation={0}
+                        <Box
+                          className="subchapter-shell"
                           sx={{
                             width: '100%',
-                            boxShadow: 'none',
-                            '&:before': { display: 'none' },
-                            backgroundColor: 'transparent',
+                            px: { xs: 1.5, md: 2.5 },
                           }}
                         >
-                          <AccordionSummary
-                            expandIcon={<ExpandMoreIcon sx={{ fontSize: 20 }} />}
+                          <Accordion
+                            expanded={isSubchapterExpanded}
+                            onChange={handleSubchapterChange(subchapter.id)}
+                            elevation={0}
                             sx={{
-                              px: 3,
-                              py: 1.5,
-                              minHeight: 48,
-                              '&.Mui-expanded': {
-                                minHeight: 48,
-                              },
-                              '& .MuiAccordionSummary-content': {
-                                my: 0,
-                                '&.Mui-expanded': {
-                                  my: 0,
-                                },
-                              },
+                              width: '100%',
+                              boxShadow: 'none',
+                              '&:before': { display: 'none' },
+                              backgroundColor: 'transparent',
                             }}
                           >
-                            <Typography
-                              variant="subtitle1"
+                            <AccordionSummary
+                              expandIcon={<ExpandMoreIcon sx={{ fontSize: 20 }} />}
                               sx={{
-                                fontWeight: 500,
-                                color: 'text.primary',
+                                px: 1.5,
+                                py: 1.5,
+                                minHeight: 48,
+                                '&.Mui-expanded': {
+                                  minHeight: 48,
+                                },
+                                '& .MuiAccordionSummary-content': {
+                                  my: 0,
+                                  '&.Mui-expanded': {
+                                    my: 0,
+                                  },
+                                },
                               }}
                             >
-                              {subchapter.title}
-                            </Typography>
-                          </AccordionSummary>
+                              <Typography
+                                variant="subtitle1"
+                                sx={{
+                                  fontWeight: 500,
+                                  color: 'text.primary',
+                                }}
+                              >
+                                {subchapter.title}
+                              </Typography>
+                            </AccordionSummary>
 
-                          <AccordionDetails sx={{ px: 3, py: 2, pt: 1 }}>
-                            <Box sx={{ display: 'flex', flexDirection: 'column', gap: 1.5 }}>
-                              {subchapter.activities.map((activity, idx) =>
-                                renderActivity(activity, {
-                                  chapter,
-                                  subchapter,
-                                  activityIndex: idx,
-                                })
-                              )}
-                            </Box>
-                          </AccordionDetails>
-                        </Accordion>
+                            <AccordionDetails sx={{ px: 1.5, py: 2, pt: 1 }}>
+                              <Box sx={{ display: 'flex', flexDirection: 'column', gap: 1.5 }}>
+                                {subchapter.activities.map((activity, idx) =>
+                                  renderActivity(activity, {
+                                    chapter,
+                                    subchapter,
+                                    activityIndex: idx,
+                                  })
+                                )}
+                              </Box>
+                            </AccordionDetails>
+                          </Accordion>
+                        </Box>
                       </ListItem>
                     )
                   })}

--- a/src/pages/Assignments.jsx
+++ b/src/pages/Assignments.jsx
@@ -240,7 +240,10 @@ export default function Assignments() {
         <Box
           sx={{
             display: 'grid',
-            gridTemplateColumns: { xs: '1fr', md: 'minmax(0, 1fr) 440px' },
+            gridTemplateColumns: {
+              xs: '1fr',
+              md: 'minmax(0, 1fr) clamp(240px, 28vw, 360px)',
+            },
             columnGap: { xs: 0, md: 4 },
             rowGap: 2,
             alignItems: 'start',
@@ -354,6 +357,7 @@ export default function Assignments() {
       showExpandAll={showExpandAll}
       showCollapseAll={showCollapseAll}
       showExpandCollapseToggle={showExpandCollapseToggle}
+      defaultSubchapterExpanded
       persistKey={accordionStorageKey}
       renderActivity={(activity, context) =>
         renderActivity(activity, context, datePrefix, showCompletionChip)

--- a/src/pages/Assignments.jsx
+++ b/src/pages/Assignments.jsx
@@ -1,7 +1,7 @@
 import { useEffect, useMemo, useCallback, useState } from 'react'
 import { useNavigate } from 'react-router-dom'
 import { useQuery } from '@tanstack/react-query'
-import { Box, Tabs, Tab, Typography, CardContent, Chip, Stack } from '@mui/material'
+import { Box, Tabs, Tab, Typography, CardContent, Chip, Stack, LinearProgress } from '@mui/material'
 import LockIcon from '@mui/icons-material/Lock'
 import ThemedCard from '../components/ui/ThemedCard.jsx'
 import ActivityAccordion from '../components/ui/ActivityAccordion.jsx'
@@ -30,6 +30,8 @@ const buildCourseStructure = (assignments, sectionTitle) => {
       type: ACTIVITY_TYPES.HOMEWORK,
       worksheet: { id: assignment.id, proofs: [] },
       isLocked: assignment.is_locked ?? assignment.isLocked ?? false,
+      questionCount: Number(assignment.question_count) || 0,
+      answeredCount: Number(assignment.answered_count) || 0,
     })
     chapterEntry.set(subLabel, items)
     chapters.set(chapterLabel, chapterEntry)
@@ -225,18 +227,24 @@ export default function Assignments() {
     const accommodationDueLabel = policy?.accommodation_due_at
       ? formatDateTime(policy.accommodation_due_at)
       : null
+    const totalQuestions = Number(activity.questionCount) || 0
+    const completedQuestions = Math.min(Number(activity.answeredCount) || 0, totalQuestions)
+    const completionValue = totalQuestions > 0 ? (completedQuestions / totalQuestions) * 100 : 0
     return (
     <ThemedCard
       key={activity.id}
       sx={{ cursor: 'pointer', '&:hover': { boxShadow: 4 } }}
       onClick={() => handleActivityClick(activity)}
     >
-      <CardContent sx={{ pl: 0, pr: 2, pt: 2, pb: 2, '&:last-child': { pb: 2 } }}>
-        <Stack
-          direction={{ xs: 'column', sm: 'row' }}
-          justifyContent="space-between"
-          alignItems={{ xs: 'flex-start', sm: 'flex-start' }}
-          spacing={2}
+      <CardContent sx={{ p: 2, '&:last-child': { pb: 2 } }}>
+        <Box
+          sx={{
+            display: 'grid',
+            gridTemplateColumns: { xs: '1fr', md: 'minmax(0, 1fr) 440px' },
+            columnGap: { xs: 0, md: 4 },
+            rowGap: 2,
+            alignItems: 'start',
+          }}
         >
           <Box sx={{ flex: 1, minWidth: 0 }}>
             <Stack direction="row" spacing={1} alignItems="center" sx={{ mb: 1 }}>
@@ -248,7 +256,7 @@ export default function Assignments() {
               )}
             </Stack>
             <Typography variant="body2" color="text.secondary" sx={{ mb: 1 }}>
-              {chapter.title} • {subchapter.title}
+              {subchapter.title || chapter.title}
             </Typography>
             {activity.description && (
               <Typography variant="body2" color="text.secondary" sx={{ wordBreak: 'break-word' }}>
@@ -256,45 +264,81 @@ export default function Assignments() {
               </Typography>
             )}
           </Box>
-          <Stack spacing={1} alignItems={{ xs: 'flex-start', sm: 'flex-end' }} width={{ xs: '100%', sm: 'auto' }}>
-            <Stack direction="row" spacing={1} alignItems="center" flexWrap="wrap">
+          <Stack spacing={0.75} alignItems={{ xs: 'flex-start', md: 'flex-end' }} width="100%">
+            <Stack
+              direction="row"
+              spacing={1}
+              alignItems="center"
+              flexWrap={{ xs: 'wrap', md: 'nowrap' }}
+              justifyContent={{ xs: 'flex-start', md: 'flex-end' }}
+              sx={{ width: '100%' }}
+            >
+              {totalQuestions > 0 && (
+                <Stack
+                  direction="row"
+                  spacing={0.75}
+                  alignItems="center"
+                  sx={{
+                    minWidth: { xs: '100%', md: 'auto' },
+                    flex: { xs: '1 1 100%', md: '0 0 auto' },
+                    flexShrink: 0,
+                  }}
+                >
+                  <Box sx={{ width: { xs: '100%', md: 140 } }}>
+                    <LinearProgress
+                      variant="determinate"
+                      value={completionValue}
+                      aria-label={`Assignment completion: ${completedQuestions} of ${totalQuestions} complete`}
+                      sx={{
+                        height: 8,
+                        borderRadius: 999,
+                        bgcolor: 'action.hover',
+                        '& .MuiLinearProgress-bar': { borderRadius: 999 },
+                      }}
+                    />
+                  </Box>
+                  <Typography variant="body2" sx={{ color: 'text.primary', fontWeight: 600, whiteSpace: 'nowrap' }}>
+                    {completedQuestions}/{totalQuestions}
+                  </Typography>
+                </Stack>
+              )}
               <Chip
                 label={activity.type === ACTIVITY_TYPES.HOMEWORK ? 'Homework' : activity.type === ACTIVITY_TYPES.QUIZ ? 'Quiz' : 'Exam'}
                 size="small"
                 color="primary"
                 variant="outlined"
               />
-              {activity.dueDate && parseDueDateAsEastern(activity.dueDate, activity.dueTime) < new Date() && (
+              {activity.dueDate && !getCompletionStatus(activity.id) && parseDueDateAsEastern(activity.dueDate, activity.dueTime) < new Date() && (
                 <Chip label="Past due" size="small" color="error" />
               )}
+              {showCompletionChip && getCompletionStatus(activity.id) && (
+                <Chip label="Completed" size="small" color="success" />
+              )}
             </Stack>
-            <Typography variant="body2" color="text.secondary">
+            <Typography variant="body2" color="text.secondary" sx={{ width: '100%', textAlign: { xs: 'left', md: 'right' } }}>
               {datePrefix}{formatDateTime(activity.dueDate) || 'No due date'}
             </Typography>
             {(extensionDueLabel || accommodationDueLabel) && (
-              <Stack spacing={0.25} alignItems="flex-end">
-                {extensionDueLabel && (
-                  <Typography variant="caption" color="text.secondary" align="right">
-                    Extension: {extensionDueLabel}
-                  </Typography>
-                )}
-                {accommodationDueLabel && (
-                  <Typography variant="caption" color="text.secondary" align="right">
-                    Accommodation: {accommodationDueLabel}
-                  </Typography>
-                )}
-              </Stack>
-            )}
+              <Stack spacing={0.25} alignItems={{ xs: 'flex-start', md: 'flex-end' }} sx={{ width: '100%' }}>
+              {extensionDueLabel && (
+                <Typography variant="caption" color="text.secondary" align="right">
+                  Extension: {extensionDueLabel}
+                </Typography>
+              )}
+              {accommodationDueLabel && (
+                <Typography variant="caption" color="text.secondary" align="right">
+                  Accommodation: {accommodationDueLabel}
+                </Typography>
+              )}
+            </Stack>
+          )}
             {policy?.late_penalty_waived && (
-              <Typography variant="caption" color="text.secondary" align="right">
+              <Typography variant="caption" color="text.secondary" align="right" sx={{ width: '100%', textAlign: { xs: 'left', md: 'right' } }}>
                 Late penalty waived
               </Typography>
             )}
-            {showCompletionChip && getCompletionStatus(activity.id) && (
-              <Chip label="Completed" size="small" color="success" />
-            )}
           </Stack>
-        </Stack>
+        </Box>
       </CardContent>
     </ThemedCard>
     )

--- a/src/pages/Assignments.jsx
+++ b/src/pages/Assignments.jsx
@@ -258,9 +258,6 @@ export default function Assignments() {
                 <LockIcon sx={{ fontSize: '1.25rem', color: 'text.secondary', flexShrink: 0 }} />
               )}
             </Stack>
-            <Typography variant="body2" color="text.secondary" sx={{ mb: 1 }}>
-              {subchapter.title || chapter.title}
-            </Typography>
             {activity.description && (
               <Typography variant="body2" color="text.secondary" sx={{ wordBreak: 'break-word' }}>
                 {activity.description}

--- a/src/pages/Practice.jsx
+++ b/src/pages/Practice.jsx
@@ -151,9 +151,6 @@ export default function Practice() {
                   <Typography variant="h6" sx={{ mb: 1, wordBreak: 'break-word' }}>
                     {activity.title}
                   </Typography>
-                  <Typography variant="body2" color="text.secondary" sx={{ mb: 1 }}>
-                    {subchapter.title || chapter.title}
-                  </Typography>
                   {activity.description && (
                     <Typography variant="body2" color="text.secondary" sx={{ wordBreak: 'break-word' }}>
                       {activity.description}

--- a/src/pages/Practice.jsx
+++ b/src/pages/Practice.jsx
@@ -122,6 +122,7 @@ export default function Practice() {
         courseStructure={courseStructure}
         isLoading={isLoadingPractice}
         emptyText="No practice problems available"
+        defaultSubchapterExpanded
         renderActivity={(activity, { chapter, subchapter }) => (
           (() => {
             const totalQuestions = Number(activity.questionCount) || 0
@@ -137,7 +138,10 @@ export default function Practice() {
               <Box
                 sx={{
                   display: 'grid',
-                  gridTemplateColumns: { xs: '1fr', md: 'minmax(0, 1fr) 440px' },
+                  gridTemplateColumns: {
+                    xs: '1fr',
+                    md: 'minmax(0, 1fr) clamp(240px, 28vw, 360px)',
+                  },
                   columnGap: { xs: 0, md: 4 },
                   rowGap: 2,
                   alignItems: 'start',

--- a/src/pages/Practice.jsx
+++ b/src/pages/Practice.jsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from 'react'
 import { useNavigate } from 'react-router-dom'
-import { Box, Typography, CardContent, Chip, Stack } from '@mui/material'
+import { Box, Typography, CardContent, Chip, Stack, LinearProgress } from '@mui/material'
 import ThemedCard from '../components/ui/ThemedCard.jsx'
 import ActivityAccordion from '../components/ui/ActivityAccordion.jsx'
 import { ACTIVITY_TYPES } from '../placeholder/courseActivities.js'
@@ -23,6 +23,8 @@ const buildCourseStructure = (assignments, sectionTitle) => {
       dueDate: assignment.due_at ?? assignment.due_date,
       type: ACTIVITY_TYPES.PRACTICE,
       worksheet: { id: assignment.id, proofs: [] },
+      questionCount: Number(assignment.question_count) || 0,
+      answeredCount: Number(assignment.answered_count) || 0,
     })
     chapterEntry.set(subLabel, items)
     chapters.set(chapterLabel, chapterEntry)
@@ -121,24 +123,32 @@ export default function Practice() {
         isLoading={isLoadingPractice}
         emptyText="No practice problems available"
         renderActivity={(activity, { chapter, subchapter }) => (
+          (() => {
+            const totalQuestions = Number(activity.questionCount) || 0
+            const completedQuestions = Math.min(Number(activity.answeredCount) || 0, totalQuestions)
+            const completionValue = totalQuestions > 0 ? (completedQuestions / totalQuestions) * 100 : 0
+            return (
           <ThemedCard
             key={activity.id}
             sx={{ cursor: 'pointer', '&:hover': { boxShadow: 4 } }}
             onClick={() => handleActivityClick(activity)}
           >
             <CardContent>
-              <Stack
-                direction={{ xs: 'column', sm: 'row' }}
-                justifyContent="space-between"
-                alignItems={{ xs: 'flex-start', sm: 'flex-start' }}
-                spacing={2}
+              <Box
+                sx={{
+                  display: 'grid',
+                  gridTemplateColumns: { xs: '1fr', md: 'minmax(0, 1fr) 440px' },
+                  columnGap: { xs: 0, md: 4 },
+                  rowGap: 2,
+                  alignItems: 'start',
+                }}
               >
                 <Box sx={{ flex: 1, minWidth: 0 }}>
                   <Typography variant="h6" sx={{ mb: 1, wordBreak: 'break-word' }}>
                     {activity.title}
                   </Typography>
                   <Typography variant="body2" color="text.secondary" sx={{ mb: 1 }}>
-                    {chapter.title} • {subchapter.title}
+                    {subchapter.title || chapter.title}
                   </Typography>
                   {activity.description && (
                     <Typography variant="body2" color="text.secondary" sx={{ wordBreak: 'break-word' }}>
@@ -151,16 +161,58 @@ export default function Practice() {
                     </Typography>
                   )}
                 </Box>
-                <Chip
-                  label="Practice"
-                  size="small"
-                  color="primary"
-                  variant="outlined"
-                  sx={{ alignSelf: { xs: 'flex-start', sm: 'center' } }}
-                />
-              </Stack>
+                <Stack spacing={0.75} alignItems={{ xs: 'flex-start', md: 'flex-end' }} width="100%">
+                  <Stack
+                    direction="row"
+                    spacing={1}
+                    alignItems="center"
+                    flexWrap={{ xs: 'wrap', md: 'nowrap' }}
+                    justifyContent={{ xs: 'flex-start', md: 'flex-end' }}
+                    sx={{ width: '100%' }}
+                  >
+                    {totalQuestions > 0 && (
+                      <Stack
+                        direction="row"
+                        spacing={0.75}
+                        alignItems="center"
+                        sx={{
+                          minWidth: { xs: '100%', md: 'auto' },
+                          flex: { xs: '1 1 100%', md: '0 0 auto' },
+                          flexShrink: 0,
+                        }}
+                      >
+                        <Box sx={{ width: { xs: '100%', md: 140 } }}>
+                          <LinearProgress
+                            variant="determinate"
+                            value={completionValue}
+                            aria-label={`Practice completion: ${completedQuestions} of ${totalQuestions} complete`}
+                            sx={{
+                              height: 8,
+                              borderRadius: 999,
+                              bgcolor: 'action.hover',
+                              '& .MuiLinearProgress-bar': { borderRadius: 999 },
+                            }}
+                          />
+                        </Box>
+                        <Typography variant="body2" sx={{ color: 'text.primary', fontWeight: 600, whiteSpace: 'nowrap' }}>
+                          {completedQuestions}/{totalQuestions}
+                        </Typography>
+                      </Stack>
+                    )}
+                    <Chip
+                      label="Practice"
+                      size="small"
+                      color="primary"
+                      variant="outlined"
+                      sx={{ alignSelf: { xs: 'flex-start', md: 'flex-end' } }}
+                    />
+                  </Stack>
+                </Stack>
+              </Box>
             </CardContent>
           </ThemedCard>
+            )
+          })()
         )}
       />
     </Box>


### PR DESCRIPTION
## 🔗 Linked Issue

Closes #3 

## 📝 Description

This pr updates the student assignments and practice experience by adding completion progress, removing misleading past due chips for completed work, and refining the assignment card/accordion and question navigation layout for better readability on desktop and mobile.

## 🚀 Type of Change

- [ ] 🐛 Bug fix
- [x] ✨ New feature
- [ ] 🛠️ Refactor / Chore (Code cleanup, dependency update, etc.)

## 🧪 How to Test

1. Pull down this branch and run `npm run dev`
2. Navigate to the Assignments page on a student or TA account
3. Check all 3 tabs and verify that assignment cards show the updated layout and progress ui
5. Open a completed overdue assignment and confirm that there isn't a `Past due` chip 
6. Open an incomplete overdue assignment and confirm that the `Past due` chip still appears
7. Confirm that subchapters are expanded by default
10. Open an assignment with multiple problems and verify that the proof tab spacing looks correct on desktop

## ✅ Pre-Merge Checklist

- [x] I have performed a self-review of my own code.
- [x] I have removed all temporary `console.log`s and debuggers.
- [x] I have successfully rebased / resolved any merge conflicts with `main`.
- [x] UI looks good on both desktop and mobile viewports.
