### PR TITLE
[BUGFIX] average calculated by only past-due assignments

### DIFF
--- a/src/components/ui/StudentProfileModal.jsx
+++ b/src/components/ui/StudentProfileModal.jsx
@@ -47,17 +47,7 @@ import { formatDate } from "../../utils/formatting.js";
 import { formatEasternFromIso, formatEasternDateTime } from "../../utils/easternTime.js";
 import { MetricCard } from "./MetricCard";
 import { fetchJson } from "../../utils/api.js";
-
-// Helper function to calculate average
-function calculateAverage(grades) {
-  const validGrades = Object.values(grades).filter(
-    (g) => g !== undefined && g !== null && !isNaN(g)
-  );
-  if (validGrades.length === 0) return 0;
-  return Math.round(
-    validGrades.reduce((sum, grade) => sum + grade, 0) / validGrades.length
-  );
-}
+import { averagePercentPastDueAssignmentsRounded } from "../../utils/studentGradeAverage.js";
 
 function calculateTrend(grades, assignments) {
   if (assignments.length < 3) return null;
@@ -332,7 +322,7 @@ export default function StudentProfileModal({
     }
   };
 
-  const average = calculateAverage(student.grades);
+  const average = averagePercentPastDueAssignmentsRounded(student, assignments || []);
   const letterGrade = getLetterGrade(average, gradingScale);
   const gradeColorVariant = getGradeColorVariant(average, gradingScale);
 

--- a/src/components/ui/dashboard/AssignmentOverviewTable.jsx
+++ b/src/components/ui/dashboard/AssignmentOverviewTable.jsx
@@ -104,12 +104,16 @@ export const AssignmentOverviewTable = ({
     assignmentsWithMetrics.reduce((sum, a) => sum + a.submissions, 0);
   const totalPossible =
     totalPossibleProp ?? assignments.length * totalStudents;
+  const now = new Date();
+  const pastDueForAvg = assignmentsWithMetrics.filter(
+    (a) => a.dueAt && a.dueAt <= now
+  );
   const totalAverage =
     totalAverageProp ??
-    (assignmentsWithMetrics.length > 0
+    (pastDueForAvg.length > 0
       ? Math.round(
-          assignmentsWithMetrics.reduce((sum, a) => sum + a.average, 0) /
-            assignmentsWithMetrics.length
+          pastDueForAvg.reduce((sum, a) => sum + a.average, 0) /
+            pastDueForAvg.length
         )
       : 0);
   const completionRate =

--- a/src/components/ui/dashboard/StudentsAtRiskTable.jsx
+++ b/src/components/ui/dashboard/StudentsAtRiskTable.jsx
@@ -10,7 +10,7 @@ import {
   Chip,
   alpha,
 } from "@mui/material";
-import { useCoursesState } from "../../../context/CoursesContext";
+import { useCoursesState, getStudentsAtRisk } from "../../../context/CoursesContext";
 import {
   getLetterGrade,
   getGradeColorVariant,
@@ -33,21 +33,12 @@ export const StudentsAtRiskTable = ({ students, assignments }) => {
       ? sortedScale[1].minPercent // Second lowest grade (e.g., D = 60)
       : 70; // Default to 70 if only one grade level
 
-  const atRiskStudents = students
-    .map((student) => {
-      const grades = Object.values(student.grades).filter(
-        (g) => g !== undefined && g !== null
-      );
-      const avg =
-        grades.length > 0
-          ? Math.round(grades.reduce((sum, g) => sum + g, 0) / grades.length)
-          : 0;
-      const missing = assignments.length - grades.length;
-      const letterGrade = getLetterGrade(avg, gradingScale);
-      return { ...student, avg, missing, letterGrade };
+  const atRiskStudents = getStudentsAtRisk(students, assignments, atRiskThreshold).map(
+    (student) => ({
+      ...student,
+      letterGrade: getLetterGrade(student.avg, gradingScale),
     })
-    .filter((s) => s.avg < atRiskThreshold && s.avg > 0)
-    .sort((a, b) => a.avg - b.avg);
+  );
 
   // Get the grade level name for the threshold for display
   const thresholdGrade = gradingScale.find(

--- a/src/components/ui/gradebook/GradebookTable.jsx
+++ b/src/components/ui/gradebook/GradebookTable.jsx
@@ -20,18 +20,8 @@ import {
   isPassingGrade,
   getDefaultGradingScale,
 } from "../../../utils/gradingUtils";
+import { calculateOverallGradebookAverage } from "../../../utils/GradebookUtils";
 import StudentProfileModal from "../StudentProfileModal";
-
-// Helper function to calculate average
-function calculateAverage(grades) {
-  const validGrades = Object.values(grades).filter(
-    (g) => g !== undefined && g !== null && !isNaN(g)
-  );
-  if (validGrades.length === 0) return 0;
-  return Math.round(
-    validGrades.reduce((sum, grade) => sum + grade, 0) / validGrades.length
-  );
-}
 
 function splitAssignmentTitle(name = "") {
   const trimmed = String(name || "").trim();
@@ -197,7 +187,7 @@ export default function GradebookTable({
 
             <TableBody>
               {students.map((student) => {
-                const average = calculateAverage(student.grades);
+                const average = calculateOverallGradebookAverage(student, assignments);
                 const letterGrade = getLetterGrade(average, gradingScale);
                 const gradeColorVariant = getGradeColorVariant(
                   average,

--- a/src/components/ui/roster/StudentsTable.jsx
+++ b/src/components/ui/roster/StudentsTable.jsx
@@ -92,6 +92,7 @@ export default function StudentsTable({
           <TableBody>
             {students.map((student) => {
               const stats = getStudentStats(student);
+              const hasPastDueBasis = (stats.pastDueCount ?? 0) > 0;
               const letterGrade =
                 stats.average >= 90
                   ? "A"
@@ -138,12 +139,12 @@ export default function StudentsTable({
                       variant="body2"
                       fontWeight={600}
                       color={
-                        stats.completed > 0 && stats.average < 70
+                        hasPastDueBasis && stats.average < 70
                           ? "error.main"
                           : "text.primary"
                       }
                     >
-                      {stats.completed > 0 ? `${stats.average}%` : "—"}
+                      {hasPastDueBasis ? `${stats.average}%` : "—"}
                     </Typography>
                   </TableCell>
 
@@ -151,7 +152,7 @@ export default function StudentsTable({
                     align="center"
                     onClick={() => onStudentClick(student)}
                   >
-                    {stats.completed > 0 ? (
+                    {hasPastDueBasis ? (
                       <Chip
                         label={letterGrade}
                         color={gradeColor}

--- a/src/context/CoursesContext.jsx
+++ b/src/context/CoursesContext.jsx
@@ -3,19 +3,11 @@ import { fetchJson, getStoredUser } from "../utils/api.js";
 import { sortAssignmentsBySubchapter } from "../utils/assignmentSort.js";
 import { isInstructorRole } from "../utils/auth.js";
 import { parseDueDateAsEastern } from "../utils/easternTime.js";
+import { DEFAULT_GRADING_SCALE } from "../utils/gradingScaleDefaults.js";
 
 // ============================================================================
 // CONSTANTS
 // ============================================================================
-
-// Default grading scale
-const DEFAULT_GRADING_SCALE = [
-  { letter: "A", minPercent: 90, maxPercent: 100, color: "#10b981" },
-  { letter: "B", minPercent: 80, maxPercent: 89, color: "#6366f1" },
-  { letter: "C", minPercent: 70, maxPercent: 79, color: "#f59e0b" },
-  { letter: "D", minPercent: 60, maxPercent: 69, color: "#f97316" },
-  { letter: "F", minPercent: 0, maxPercent: 59, color: "#ef4444" },
-];
 
 // Default late policy
 const DEFAULT_LATE_POLICY = {
@@ -292,62 +284,10 @@ export function calculatePracticeCompletion(practiceId, students) {
   };
 }
 
-// Calculate grade distribution with custom grading scale
-export function calculateGradeDistribution(students, gradingScale) {
-  // Use default grading scale if none provided or if gradingScale is undefined
-  const scale =
-    gradingScale && Array.isArray(gradingScale)
-      ? gradingScale
-      : DEFAULT_GRADING_SCALE;
-
-  const distribution = scale.map((grade) => ({
-    grade: grade.letter,
-    range: `${grade.minPercent}-${grade.maxPercent}`,
-    count: 0,
-    color: grade.color,
-    minPercent: grade.minPercent,
-    maxPercent: grade.maxPercent,
-  }));
-
-  students.forEach((student) => {
-    const grades = Object.values(student.grades).filter(
-      (g) => g !== undefined && g !== null
-    );
-    if (grades.length === 0) return;
-
-    const average = Math.round(
-      grades.reduce((sum, g) => sum + g, 0) / grades.length
-    );
-
-    const gradeIndex = distribution.findIndex(
-      (d) => average >= d.minPercent && average <= d.maxPercent
-    );
-
-    if (gradeIndex !== -1) {
-      distribution[gradeIndex].count++;
-    }
-  });
-
-  return distribution;
-}
-
-// Calculate students at risk (below 70%)
-export function getStudentsAtRisk(students, assignments) {
-  return students
-    .map((student) => {
-      const grades = Object.values(student.grades).filter(
-        (g) => g !== undefined && g !== null
-      );
-      const avg =
-        grades.length > 0
-          ? Math.round(grades.reduce((sum, g) => sum + g, 0) / grades.length)
-          : 0;
-      const missing = assignments.length - grades.length;
-      return { ...student, avg, missing };
-    })
-    .filter((s) => s.avg < 70 && s.avg > 0)
-    .sort((a, b) => a.avg - b.avg);
-}
+export {
+  calculateGradeDistribution,
+  getStudentsAtRisk,
+} from "../utils/pastDueGradeRollups.js";
 
 // Get upcoming deadlines (within 7 days); due dates compared in Eastern
 export function getUpcomingDeadlines(assignments) {

--- a/src/pages/Dashboard.jsx
+++ b/src/pages/Dashboard.jsx
@@ -140,12 +140,20 @@ export default function Dashboard() {
     const gradeMap = new Map(
       (grades || []).map((g) => [g.assignment_id ?? g.Assignment?.id, g])
     )
+    const nowMs = Date.now()
+    const isSummaryPastDue = (row) => {
+      const raw = row?.due_at ?? row?.due_date
+      if (!raw) return false
+      const d = new Date(raw)
+      return !Number.isNaN(d.getTime()) && d.getTime() <= nowMs
+    }
     const unlockedSummary = gradebookSummary?.length
       ? gradebookSummary.filter((a) => a.is_locked === false)
       : []
+    const unlockedPastDueSummary = unlockedSummary.filter(isSummaryPastDue)
     const timeline =
-      unlockedSummary.length > 0
-        ? unlockedSummary
+      unlockedPastDueSummary.length > 0
+        ? unlockedPastDueSummary
             .slice()
             .sort((a, b) => {
               const aDate = (a.due_at ?? a.due_date) ? new Date(a.due_at ?? a.due_date) : null
@@ -189,8 +197,8 @@ export default function Dashboard() {
             .filter((item) => item.studentPercent != null)
             .sort((a, b) => new Date(a.date) - new Date(b.date))
     const assignmentPercents =
-      unlockedSummary.length > 0
-        ? unlockedSummary.map((assignment) => {
+      unlockedPastDueSummary.length > 0
+        ? unlockedPastDueSummary.map((assignment) => {
             const grade = gradeMap.get(assignment.id)
             const max = grade?.max_score ?? 0
             const score = grade?.final_score ?? grade?.raw_score ?? null
@@ -211,8 +219,8 @@ export default function Dashboard() {
               return list
             }, [])
     const totalAssignments =
-      unlockedSummary.length > 0
-        ? unlockedSummary.length
+      unlockedPastDueSummary.length > 0
+        ? unlockedPastDueSummary.length
         : analyticsData?.assignments?.total ?? gradebookSummary?.length ?? grades?.length ?? 0
     const completedCount = assignmentPercents.filter((a) => a.percent > 0).length
     let overallPercent = null
@@ -228,9 +236,11 @@ export default function Dashboard() {
         ? classAvgWithDrop
         : (() => {
             const forAvg =
-              unlockedSummary.length > 0
-                ? unlockedSummary
-                : (gradebookSummary || []).filter((a) => a.is_locked === false)
+              unlockedPastDueSummary.length > 0
+                ? unlockedPastDueSummary
+                : (gradebookSummary || []).filter(
+                    (a) => a.is_locked === false && isSummaryPastDue(a)
+                  )
             const vals = forAvg
               .map((a) => a.avg_percent)
               .filter((v) => v != null)
@@ -433,11 +443,11 @@ export default function Dashboard() {
                 })}
               >
                 <Typography component="div" variant="body2" sx={{ mb: 1 }}>
-                  Grade = average of published assignments.
+                  Grade = average of published assignments whose due date has passed.
                   <br />
-                  Unattempted work counts as 0%.
+                  Unattempted past-due work counts as 0%. Upcoming assignments are excluded.
                   <br />
-                  Lowest 2 scores dropped after 3+ assignments.
+                  Lowest 2 scores dropped after 3+ past-due assignments.
                 </Typography>
                 <Typography variant="body2" color="text.secondary">
                   {gradeOverview.total

--- a/src/pages/Grades.jsx
+++ b/src/pages/Grades.jsx
@@ -8,6 +8,7 @@ import { formatDateTime } from '../utils/formatting.js'
 import { API_CONFIG, fetchJson, getActiveUserId } from '../utils/api.js'
 import { useCoursesState } from '../context/CoursesContext.jsx'
 import { sortAssignmentsBySubchapter } from '../utils/assignmentSort.js'
+import { getAssignmentDeadlineInstant } from '../utils/studentGradeAverage.js'
 
 function NoRowsOverlay() {
   return (
@@ -55,25 +56,29 @@ export default function Grades() {
     }))
   }, [courseIdForApi, assignments, grades])
 
-  const assignmentPercents = useMemo(() => {
-    return gradeEntries.map((entry) => {
-      const grade = entry.grade
-      const max = grade?.max_score ?? entry.assignment?.total_points ?? 0
-      const score = grade?.final_score ?? grade?.raw_score ?? null
-      const percent =
-        max > 0 && score !== null && score !== undefined ? (score / max) * 100 : 0
-      return percent
-    })
+  const pastDuePercents = useMemo(() => {
+    const nowMs = Date.now()
+    return gradeEntries
+      .filter((entry) => {
+        const d = getAssignmentDeadlineInstant(entry.assignment)
+        return d && d.getTime() <= nowMs
+      })
+      .map((entry) => {
+        const grade = entry.grade
+        const max = grade?.max_score ?? entry.assignment?.total_points ?? 0
+        const score = grade?.final_score ?? grade?.raw_score ?? null
+        return max > 0 && score !== null && score !== undefined ? (score / max) * 100 : 0
+      })
   }, [gradeEntries])
 
   const overallPercentage = useMemo(() => {
-    if (assignmentPercents.length === 0) return 0
+    if (pastDuePercents.length === 0) return 0
     let forAverage =
-      assignmentPercents.length >= 3
-        ? [...assignmentPercents].sort((a, b) => a - b).slice(2)
-        : assignmentPercents
+      pastDuePercents.length >= 3
+        ? [...pastDuePercents].sort((a, b) => a - b).slice(2)
+        : pastDuePercents
     return forAverage.reduce((s, p) => s + p, 0) / forAverage.length
-  }, [assignmentPercents])
+  }, [pastDuePercents])
 
   const rows = useMemo(
     () =>

--- a/src/pages/instructor/InstructorDashboard.jsx
+++ b/src/pages/instructor/InstructorDashboard.jsx
@@ -172,7 +172,8 @@ export default function InstructorDashboard() {
   // Pass the course's grading scale to calculateGradeDistribution
   const gradeDistribution = calculateGradeDistribution(
     studentsForAssignments,
-    course?.gradingScale
+    course?.gradingScale,
+    nonPracticeAssignments
   );
 
   const isGradedAndUnlocked = (assignment) => {
@@ -269,7 +270,7 @@ export default function InstructorDashboard() {
         <MetricCard
           title="Class Average"
           value={`${totalAverage}%`}
-          subtitle="Across all assignments"
+          subtitle="Past-due assignments only"
           icon={TrendingUp}
           gradient={["#10b981", "#059669"]}
         />

--- a/src/pages/instructor/InstructorGradebook.jsx
+++ b/src/pages/instructor/InstructorGradebook.jsx
@@ -33,7 +33,7 @@ export default function InstructorGradebook() {
   }
 
   // Apply sorting
-  const sortedStudents = sortStudents(students, sortColumn, sortDirection);
+  const sortedStudents = sortStudents(students, sortColumn, sortDirection, assignments);
 
   // Handle sort column click
   const handleSort = (column) => {

--- a/src/utils/GradebookUtils.js
+++ b/src/utils/GradebookUtils.js
@@ -1,8 +1,8 @@
-// Calculate average grade from grades object
-export function calculateAverage(grades) {
-  const values = Object.values(grades);
-  if (values.length === 0) return 0;
-  return Math.round(values.reduce((a, b) => a + b, 0) / values.length);
+import { averagePercentPastDueAssignmentsRounded } from "./studentGradeAverage.js";
+
+/** Row average: mean over officially past-due assignments only (missing = 0). */
+export function calculateOverallGradebookAverage(student, assignments) {
+  return averagePercentPastDueAssignmentsRounded(student, assignments || []);
 }
 
 // Get letter grade from numeric grade
@@ -19,7 +19,8 @@ export function filterStudents(
   students,
   searchTerm,
   selectedAssignment,
-  gradeFilter
+  gradeFilter,
+  assignments = []
 ) {
   return students.filter((student) => {
     // Search filter
@@ -42,7 +43,7 @@ export function filterStudents(
       if (gradeFilter === "f" && grade >= 60) return false;
     } else if (gradeFilter !== "all") {
       // Overall average filter
-      const average = calculateAverage(student.grades);
+      const average = calculateOverallGradebookAverage(student, assignments);
       if (gradeFilter === "a" && average < 90) return false;
       if (gradeFilter === "b" && (average < 80 || average >= 90)) return false;
       if (gradeFilter === "c" && (average < 70 || average >= 80)) return false;
@@ -55,7 +56,7 @@ export function filterStudents(
 }
 
 // Sort students by column
-export function sortStudents(students, sortColumn, sortDirection) {
+export function sortStudents(students, sortColumn, sortDirection, assignments = []) {
   return [...students].sort((a, b) => {
     let aValue, bValue;
 
@@ -66,8 +67,8 @@ export function sortStudents(students, sortColumn, sortDirection) {
         ? aValue.localeCompare(bValue)
         : bValue.localeCompare(aValue);
     } else if (sortColumn === "average") {
-      aValue = calculateAverage(a.grades);
-      bValue = calculateAverage(b.grades);
+      aValue = calculateOverallGradebookAverage(a, assignments);
+      bValue = calculateOverallGradebookAverage(b, assignments);
     } else {
       aValue = a.grades[sortColumn] ?? -1;
       bValue = b.grades[sortColumn] ?? -1;
@@ -117,7 +118,7 @@ export function exportGradebookCSV(students, assignments, courseLabel) {
   const rows = [
     ["Username", "Average", "Letter Grade", ...assignmentHeaders],
     ...students.map((student) => {
-      const average = calculateAverage(student?.grades || {});
+      const average = calculateOverallGradebookAverage(student, assignmentList);
       const letterGrade = getLetterGrade(average);
       const grades = student?.grades || {};
       const assignmentGrades = assignmentList.map((assignment) => {

--- a/src/utils/gradingScaleDefaults.js
+++ b/src/utils/gradingScaleDefaults.js
@@ -1,0 +1,11 @@
+/**
+ * Default letter-grade bands (percent min/max). Shared by course defaults and
+ * analytics rollups so scale and distribution logic stay aligned.
+ */
+export const DEFAULT_GRADING_SCALE = [
+  { letter: "A", minPercent: 90, maxPercent: 100, color: "#10b981" },
+  { letter: "B", minPercent: 80, maxPercent: 89, color: "#6366f1" },
+  { letter: "C", minPercent: 70, maxPercent: 79, color: "#f59e0b" },
+  { letter: "D", minPercent: 60, maxPercent: 69, color: "#f97316" },
+  { letter: "F", minPercent: 0, maxPercent: 59, color: "#ef4444" },
+];

--- a/src/utils/gradingUtils.js
+++ b/src/utils/gradingUtils.js
@@ -1,3 +1,5 @@
+import { DEFAULT_GRADING_SCALE } from "./gradingScaleDefaults.js";
+
 /**
  * Get letter grade based on percentage and course grading scale
  * @param {number} percentage - The grade percentage (0-100)
@@ -66,71 +68,6 @@ export function getGradeColorVariant(percentage, gradingScale) {
 }
 
 /**
- * Calculate grade distribution based on grading scale
- * @param {Array} students - Array of student objects with grades
- * @param {Array} gradingScale - The course's grading scale configuration
- * @returns {Array} Distribution array with counts for each grade level
- */
-export function calculateGradeDistribution(students, gradingScale) {
-  // Initialize distribution with the custom grading scale
-  const distribution = gradingScale.map((grade) => ({
-    grade: grade.letter,
-    range: `${grade.minPercent}-${grade.maxPercent}`,
-    count: 0,
-    color: grade.color,
-    minPercent: grade.minPercent,
-    maxPercent: grade.maxPercent,
-  }));
-
-  students.forEach((student) => {
-    const grades = Object.values(student.grades).filter(
-      (g) => g !== undefined && g !== null && !isNaN(g)
-    );
-
-    if (grades.length === 0) return;
-
-    const average = Math.round(
-      grades.reduce((sum, g) => sum + g, 0) / grades.length
-    );
-
-    // Find which grade bracket this average falls into
-    const gradeIndex = distribution.findIndex(
-      (d) => average >= d.minPercent && average <= d.maxPercent
-    );
-
-    if (gradeIndex !== -1) {
-      distribution[gradeIndex].count++;
-    }
-  });
-
-  return distribution;
-}
-
-/**
- * Get students at risk based on a threshold
- * @param {Array} students - Array of student objects
- * @param {Array} assignments - Array of assignments
- * @param {number} threshold - Grade percentage threshold (default 70)
- * @returns {Array} Students below threshold, sorted by average
- */
-export function getStudentsAtRisk(students, assignments, threshold = 70) {
-  return students
-    .map((student) => {
-      const grades = Object.values(student.grades).filter(
-        (g) => g !== undefined && g !== null && !isNaN(g)
-      );
-      const avg =
-        grades.length > 0
-          ? Math.round(grades.reduce((sum, g) => sum + g, 0) / grades.length)
-          : 0;
-      const missing = assignments.length - grades.length;
-      return { ...student, avg, missing };
-    })
-    .filter((s) => s.avg < threshold && s.avg > 0)
-    .sort((a, b) => a.avg - b.avg);
-}
-
-/**
  * Check if a grade is passing based on grading scale
  * Typically, the lowest passing grade is anything above the lowest grade level
  * @param {number} percentage - The grade percentage
@@ -162,11 +99,7 @@ export function isPassingGrade(percentage, gradingScale) {
  * @returns {Array} Default grading scale
  */
 export function getDefaultGradingScale() {
-  return [
-    { letter: "A", minPercent: 90, maxPercent: 100, color: "#10b981" },
-    { letter: "B", minPercent: 80, maxPercent: 89, color: "#6366f1" },
-    { letter: "C", minPercent: 70, maxPercent: 79, color: "#f59e0b" },
-    { letter: "D", minPercent: 60, maxPercent: 69, color: "#f97316" },
-    { letter: "F", minPercent: 0, maxPercent: 59, color: "#ef4444" },
-  ];
+  return DEFAULT_GRADING_SCALE.map((g) => ({ ...g }));
 }
+
+export { calculateGradeDistribution, getStudentsAtRisk } from "./pastDueGradeRollups.js";

--- a/src/utils/pastDueGradeRollups.js
+++ b/src/utils/pastDueGradeRollups.js
@@ -1,0 +1,75 @@
+import {
+  averagePercentPastDueAssignments,
+  averagePercentPastDueAssignmentsRounded,
+  listPastDueGradedAssignments,
+} from "./studentGradeAverage.js";
+import { DEFAULT_GRADING_SCALE } from "./gradingScaleDefaults.js";
+
+/**
+ * Histogram of students by letter bucket, using each student's **past-due-only**
+ * average (see `studentGradeAverage.js`).
+ *
+ * @param {Array<object>} students - Gradebook-shaped students (`grades`, etc.)
+ * @param {Array<object>|undefined} gradingScale - Course scale; falls back to default
+ * @param {Array<object>} assignments - Assignments used to determine past due
+ */
+export function calculateGradeDistribution(students, gradingScale, assignments = []) {
+  const scale =
+    gradingScale && Array.isArray(gradingScale) ? gradingScale : DEFAULT_GRADING_SCALE;
+
+  const distribution = scale.map((grade) => ({
+    grade: grade.letter,
+    range: `${grade.minPercent}-${grade.maxPercent}`,
+    count: 0,
+    color: grade.color,
+    minPercent: grade.minPercent,
+    maxPercent: grade.maxPercent,
+  }));
+
+  students.forEach((student) => {
+    const avg = averagePercentPastDueAssignments(student, assignments);
+    if (avg === null) return;
+
+    const average = Math.round(avg);
+
+    const gradeIndex = distribution.findIndex(
+      (d) => average >= d.minPercent && average <= d.maxPercent
+    );
+
+    if (gradeIndex !== -1) {
+      distribution[gradeIndex].count++;
+    }
+  });
+
+  return distribution;
+}
+
+/**
+ * Students whose **past-due-only** rounded average is below `threshold`, with a
+ * `missing` count of past-due slots with no submission and no grade.
+ */
+export function getStudentsAtRisk(students, assignments, threshold = 70) {
+  const pastDue = listPastDueGradedAssignments(assignments || []);
+  return students
+    .map((student) => {
+      const avg = averagePercentPastDueAssignmentsRounded(
+        student,
+        assignments || [],
+        undefined,
+        pastDue
+      );
+      const missing = pastDue.filter((a) => {
+        const id = Number(a.id);
+        if (!Number.isFinite(id)) return false;
+        const submitted =
+          student.submittedAssignments?.[id] ||
+          student.submittedAssignments?.[String(id)];
+        if (submitted) return false;
+        const g = student.grades?.[id] ?? student.grades?.[String(id)];
+        return g === undefined || g === null;
+      }).length;
+      return { ...student, avg, missing };
+    })
+    .filter((s) => pastDue.length > 0 && s.avg < threshold)
+    .sort((a, b) => a.avg - b.avg);
+}

--- a/src/utils/rosterUtils.js
+++ b/src/utils/rosterUtils.js
@@ -1,50 +1,37 @@
 // Utility functions for roster management
-import { parseDueDateAsEastern } from "./easternTime.js";
-
-const getAssignmentDeadline = (assignment) => {
-  if (!assignment?.dueDate) return null;
-  const deadline = parseDueDateAsEastern(assignment.dueDate, assignment.dueTime);
-  return deadline && !Number.isNaN(deadline.getTime()) ? deadline : null;
-};
-
-const getPastDueAssignmentIds = (assignments) => {
-  if (!Array.isArray(assignments) || assignments.length === 0) return null;
-  const now = new Date();
-  const ids = new Set();
-  assignments.forEach((assignment) => {
-    const deadline = getAssignmentDeadline(assignment);
-    if (!deadline || deadline > now) return;
-    const assignmentId = Number(assignment.id);
-    if (Number.isFinite(assignmentId)) {
-      ids.add(assignmentId);
-    }
-  });
-  return ids;
-};
+import {
+  listPastDueGradedAssignments,
+  averagePercentPastDueAssignmentsRounded,
+} from "./studentGradeAverage.js";
 
 export function getStudentStats(student, assignments) {
-  const pastDueAssignmentIds = getPastDueAssignmentIds(assignments);
-  const grades = Object.entries(student.grades || {})
-    .filter(
-      ([assignmentId, grade]) =>
-        grade !== undefined &&
-        grade !== null &&
-        (!pastDueAssignmentIds ||
-          pastDueAssignmentIds.has(Number(assignmentId)))
-    )
-    .map(([, grade]) => grade);
+  const pastDue = listPastDueGradedAssignments(assignments || []);
+  const pastDueIds = new Set(
+    pastDue
+      .map((a) => Number(a.id))
+      .filter((id) => Number.isFinite(id))
+  );
+  const pastDueCount = pastDue.length;
   const average =
-    grades.length > 0
-      ? Math.round(grades.reduce((sum, g) => sum + g, 0) / grades.length)
+    pastDueCount > 0
+      ? averagePercentPastDueAssignmentsRounded(student, assignments || [], undefined, pastDue)
       : 0;
-  const completed = grades.length;
+  const gradesObj = student.grades || {};
+  const completed = pastDue.filter((a) => {
+    const id = Number(a.id);
+    if (!Number.isFinite(id)) return false;
+    const g = gradesObj[id] ?? gradesObj[String(id)];
+    const submitted =
+      student.submittedAssignments?.[id] ||
+      student.submittedAssignments?.[String(id)];
+    return Boolean(submitted) || (typeof g === "number" && g > 0);
+  }).length;
   const lateCount = Object.entries(student.lateSubmissions || {}).filter(
     ([assignmentId, isLate]) =>
-      Boolean(isLate) &&
-      (!pastDueAssignmentIds || pastDueAssignmentIds.has(Number(assignmentId)))
+      Boolean(isLate) && pastDueIds.has(Number(assignmentId))
   ).length;
 
-  return { average, completed, lateCount };
+  return { average, completed, lateCount, pastDueCount };
 }
 
 export function filterStudents(students, searchQuery) {
@@ -54,7 +41,7 @@ export function filterStudents(students, searchQuery) {
   );
 }
 
-/** Students onlyfor analytics */
+/** Students only (excludes TAs) for roster analytics. */
 function studentsOnlyForStats(students) {
   return Array.isArray(students)
     ? students.filter((s) => s.role !== "ta")
@@ -77,7 +64,7 @@ export function calculateClassStats(students, assignments) {
 
   const studentsAtRisk = forStats.filter((s) => {
     const stats = getStudentStats(s, assignments);
-    return stats.average < 70 && stats.average > 0;
+    return (stats.pastDueCount ?? 0) > 0 && stats.average < 70;
   }).length;
 
   return { totalStudents, averageClassGrade, studentsAtRisk };

--- a/src/utils/studentGradeAverage.js
+++ b/src/utils/studentGradeAverage.js
@@ -1,0 +1,82 @@
+import { parseDueDateAsEastern } from "./easternTime.js";
+
+/**
+ * Single instant for an assignment's official due (for "past due" checks).
+ * Prefer API ISO fields; otherwise Eastern calendar date + time from course UI.
+ */
+export function getAssignmentDeadlineInstant(assignment) {
+  if (!assignment) return null;
+  const iso = assignment.dueAt || assignment.due_at;
+  if (iso) {
+    const d = new Date(iso);
+    return Number.isNaN(d.getTime()) ? null : d;
+  }
+  const dateStr = assignment.dueDate || assignment.due_date;
+  if (!dateStr) return null;
+  const timeStr =
+    assignment.dueTime ||
+    assignment.due_time ||
+    "23:59";
+  return parseDueDateAsEastern(String(dateStr).slice(0, 10), timeStr);
+}
+
+export function isGradedCourseAssignment(assignment) {
+  return assignment?.kind !== "practice";
+}
+
+export function isAssignmentPastDue(assignment, now = new Date()) {
+  if (!isGradedCourseAssignment(assignment)) return false;
+  const deadline = getAssignmentDeadlineInstant(assignment);
+  if (!deadline) return false;
+  return deadline.getTime() <= now.getTime();
+}
+
+export function listPastDueGradedAssignments(assignments, now = new Date()) {
+  if (!Array.isArray(assignments)) return [];
+  return assignments.filter(
+    (a) => isGradedCourseAssignment(a) && isAssignmentPastDue(a, now)
+  );
+}
+
+/**
+ * Unrounded mean over past-due graded assignments only. Missing / null grade = 0.
+ * Returns null when there are no past-due assignments with a known deadline.
+ *
+ * @param {object|null} pastDueCached - If provided (e.g. from `listPastDueGradedAssignments`),
+ *   skips recomputing the past-due list (same `now` must have been used to build it).
+ */
+export function averagePercentPastDueAssignments(
+  student,
+  assignments,
+  now = new Date(),
+  pastDueCached = null
+) {
+  const pastDue = Array.isArray(pastDueCached)
+    ? pastDueCached
+    : listPastDueGradedAssignments(assignments, now);
+  if (pastDue.length === 0) return null;
+  const grades = student?.grades || {};
+  let sum = 0;
+  for (const a of pastDue) {
+    const id = Number(a.id);
+    const key = Number.isFinite(id) ? id : a.id;
+    const g = grades[key] ?? grades[String(key)];
+    const val =
+      g !== undefined && g !== null && !Number.isNaN(Number(g))
+        ? Number(g)
+        : 0;
+    sum += val;
+  }
+  return sum / pastDue.length;
+}
+
+export function averagePercentPastDueAssignmentsRounded(
+  student,
+  assignments,
+  now = new Date(),
+  pastDueCached = null
+) {
+  const avg = averagePercentPastDueAssignments(student, assignments, now, pastDueCached);
+  if (avg === null) return 0;
+  return Math.round(avg);
+}


### PR DESCRIPTION
## 🔗 Linked Issue

Closes #4 

## 📝 Description

This PR changes how course assignment averages are computed so they use only assignments whose due date has already passed (non-practice work). Upcoming assignments are no longer treated as 0% in the average.

Updates include:

- student dashboard grade card and copy
- student grades page overall %
- instructor dashboard (class average, assignment overview fallback, grade distribution, students at risk)
- gradebook table row average and CSV export, roster stats and CSV
- student profile headline average

Shared helpers live in `studentGradeAverage.js`; `calculateGradeDistribution` and `getStudentsAtRisk` are centralized in `pastDueGradeRollups.js` with a single `DEFAULT_GRADING_SCALE` in `gradingScaleDefaults.js`, re-exported from `CoursesContext` and `gradingUtils` so behavior cannot drift.
Minor UX tweaks (e.g. roster “—” when nothing is past due yet) align with the new definition.

## 🚀 Type of Change

- [X] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 🛠️ Refactor / Chore (Code cleanup, dependency update, etc.)

## 🧪 How to Test

1. Login to a student account
2. Navigate to `.../student/dashboard`
3. Confirm that the average is being calculated using only past-due assignments, and no upcoming ones (no synthetic `0`s)
4. Login to an instructor account
5. Navigate to `.../instructor/gradebook`
6. Confirm that all student averages are calculated using only past-due assignments
7. Gradebook export to CSV should also reflect these changes

## ✅ Pre-Merge Checklist

- [X] I have performed a self-review of my own code.
- [X] I have removed all temporary `console.log`s and debuggers.
- [X] I have successfully rebased / resolved any merge conflicts with `main`.
- [X] UI looks good on both desktop and mobile viewports.
