### PR TITLE
Runtime extraction

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -22,6 +22,7 @@ import InstructorControls from "./pages/instructor/InstructorControls.jsx";
 import InstructorAssignments from "./pages/instructor/InstructorAssignments.jsx";
 import AssignmentBuilder from "./pages/instructor/InstructorAssignmentBuilder.jsx";
 import Login from "./pages/Login.jsx";
+import Landing from "./pages/Landing.jsx";
 import Courses from "./pages/Courses.jsx";
 import Profile from "./pages/Profile.jsx";
 import InstructorPractice from "./pages/instructor/InstructorPractice.jsx";
@@ -33,7 +34,7 @@ function AppRoutes() {
     <Routes>
       <Route path="/login" element={<Login />} />
 
-      <Route path="/" element={<Navigate to="/login" replace />} />
+      <Route path="/" element={<Landing />} />
 
       <Route
         path="/student"

--- a/src/components/layout/AppLayout.jsx
+++ b/src/components/layout/AppLayout.jsx
@@ -1,33 +1,29 @@
-import { Box, useMediaQuery, useTheme } from "@mui/material";
 import { useNavigate, useLocation } from "react-router-dom";
-import { useEffect, useRef, useState } from "react";
-import Header from "./Header.jsx";
-import Sidebar from "./Sidebar.jsx";
+import { useEffect, useState } from "react";
 import StudentSidebarStructure from "./StudentSidebarStructure.jsx";
 import InstructorSidebarStructure from "./InstructorSidebarStructure.jsx";
-import AccountSettingsDialog from "../ui/AccountSettingsDialog.jsx";
-import RulesReference from "../ui/RulesReference.jsx";
 import { useAuthState, useAuthDispatch, logout } from "../../context/AuthContext";
-import { useCoursesDispatch, useCoursesState, initializeCourses, resetCourses } from "../../context/CoursesContext";
+import {
+  useCoursesDispatch,
+  useCoursesState,
+  initializeCourses,
+  resetCourses,
+} from "../../context/CoursesContext";
 import { clearStoredUser, fetchJson } from "../../utils/api.js";
 import { isInstructorRole } from "../../utils/auth.js";
-import { useLayoutState } from "../../context/LayoutContext.jsx";
+import { AppRuntimeProvider } from "../../context/AppRuntimeContext.jsx";
+import { createAppRuntime } from "../../runtime/appRuntime.js";
+import ShellFrame from "./ShellFrame.jsx";
 
-export default function AppLayout({ children }) {
+function AppShell({ children }) {
   const location = useLocation();
   const navigate = useNavigate();
   const { user } = useAuthState();
-  const { isRulesReferenceOpen } = useLayoutState();
   const authDispatch = useAuthDispatch();
   const coursesDispatch = useCoursesDispatch();
-  const { initialized } = useCoursesState();
-  const mainContentRef = useRef(null);
+  const coursesState = useCoursesState();
+  const { initialized } = coursesState;
   const [isAccountSettingsOpen, setIsAccountSettingsOpen] = useState(false);
-  const theme = useTheme();
-  const isLargeScreen = useMediaQuery(theme.breakpoints.up("lg"));
-  const hasDesktopPointer = useMediaQuery("(hover: hover) and (pointer: fine)");
-  const isDesktopRulebookLayout = isLargeScreen && hasDesktopPointer;
-  const shouldShiftShellForRulebook = isDesktopRulebookLayout && isRulesReferenceOpen;
 
   useEffect(() => {
     if (user?.role && user?.id && !initialized) {
@@ -35,35 +31,24 @@ export default function AppLayout({ children }) {
     }
   }, [user?.role, user?.id, initialized, coursesDispatch]);
 
-  useEffect(() => {
-    const timer = setTimeout(() => {
-      window.scrollTo({
-        top: 0,
-        left: 0,
-        behavior: "smooth",
-      });
-
-      if (mainContentRef.current) {
-        mainContentRef.current.scrollTo({
-          top: 0,
-          left: 0,
-          behavior: "smooth",
-        });
-      }
-
-    }, 0);
-
-    return () => clearTimeout(timer);
-  }, [location.pathname]);
-
   const isInstructorRoute = location.pathname.startsWith("/instructor")
     ? true
     : location.pathname.startsWith("/student")
     ? false
     : isInstructorRole(user?.role);
-  const sidebarStructure = isInstructorRoute
+  const baseSidebarStructure = isInstructorRoute
     ? InstructorSidebarStructure
     : StudentSidebarStructure;
+  const sidebarStructure = baseSidebarStructure;
+
+  const routeKind = isInstructorRoute ? "instructor" : "student";
+
+  const runtimeValue = createAppRuntime({
+    coursesDispatch,
+    coursesState,
+    routeKind,
+    user,
+  });
 
   const handleSignOut = async () => {
     try {
@@ -79,60 +64,22 @@ export default function AppLayout({ children }) {
   };
 
   return (
-    <Box
-      sx={{
-        display: "flex",
-        minHeight: "100vh",
-        minWidth: 0,
-        height: { xs: "auto", md: "100dvh" },
-        overflow: { xs: "visible", md: "hidden" },
-      }}
-    >
-      <Box
-        sx={{
-          display: "flex",
-          flexGrow: 1,
-          minWidth: 0,
-          minHeight: { xs: "auto", md: 0 },
-          overflow: { xs: "visible", md: "hidden" },
-          transform: shouldShiftShellForRulebook ? "translateX(16px)" : "translateX(0)",
-          transition: (t) =>
-            t.transitions.create("transform", {
-              duration: t.transitions.duration.shorter,
-            }),
-        }}
+    <AppRuntimeProvider value={runtimeValue}>
+      <ShellFrame
+        location={location}
+        sidebarStructure={sidebarStructure}
+        onSignOut={handleSignOut}
+        onOpenSettings={() => setIsAccountSettingsOpen(true)}
+        showAccountSettings
+        isAccountSettingsOpen={isAccountSettingsOpen}
+        onCloseAccountSettings={() => setIsAccountSettingsOpen(false)}
       >
-        <Sidebar
-          structure={sidebarStructure}
-          location={location}
-          onSignOut={handleSignOut}
-          onOpenSettings={() => setIsAccountSettingsOpen(true)}
-        />
-        <Box sx={{ display: "flex", flexDirection: "column", flexGrow: 1, minWidth: 0 }}>
-          <Header />
-          <Box
-            component="main"
-            ref={mainContentRef}
-            sx={{
-              flexGrow: 1,
-              p: 3,
-              pt: /\/assignment\/[^/]+$/.test(location.pathname) ? 2 : 3,
-              backgroundColor: "background.default",
-              minHeight: { xs: "100vh", md: 0 },
-              overflow: "auto",
-              overflowX: "hidden",
-              minWidth: 0,
-            }}
-          >
-            {children}
-          </Box>
-        </Box>
-      </Box>
-      <AccountSettingsDialog
-        open={isAccountSettingsOpen}
-        onClose={() => setIsAccountSettingsOpen(false)}
-      />
-      <RulesReference />
-    </Box>
+        {children}
+      </ShellFrame>
+    </AppRuntimeProvider>
   );
+}
+
+export default function AppLayout({ children }) {
+  return <AppShell>{children}</AppShell>;
 }

--- a/src/components/layout/Header.jsx
+++ b/src/components/layout/Header.jsx
@@ -10,10 +10,9 @@ import {
   useMediaQuery,
   useTheme,
 } from "@mui/material";
-import { Menu as MenuIcon, MenuBook as MenuBookIcon } from "@mui/icons-material";
+import { Menu as MenuIcon, MenuBook as MenuBookIcon, ArrowBack as ArrowBackIcon } from "@mui/icons-material";
 import { ChevronRight } from "lucide-react";
 import { Link as RouterLink, useLocation } from "react-router-dom";
-import { useCoursesState } from "../../context/CoursesContext";
 import ThemeToggle from "./ThemeToggle.jsx";
 import {
   useLayoutDispatch,
@@ -22,58 +21,17 @@ import {
   closeRulesReference,
   openRulesReference,
 } from "../../context/LayoutContext.jsx";
+import { useAppRuntime } from "../../hooks/useAppRuntime.js";
 
-const getBreadcrumbInfo = (pathname) => {
-  if (pathname.startsWith("/instructor/assignment/")) {
-    return { label: "Assignment", path: "/instructor/assignments" };
-  }
-  if (pathname.startsWith("/student/assignment/")) {
-    return { label: "Assignment", path: "/student/assignments" };
-  }
-  if (pathname.startsWith("/student/worksheet/")) {
-    return { label: "Worksheet", path: "/student/assignments" };
-  }
-  const routes = {
-    "/instructor/dashboard": { label: "Dashboard", path: "/instructor/dashboard" },
-    "/instructor/courses": { label: "All Courses", path: "/instructor/courses" },
-    "/instructor/assignments": { label: "Assignments", path: "/instructor/assignments" },
-    "/instructor/gradebook": { label: "Gradebook", path: "/instructor/gradebook" },
-    "/instructor/controls": { label: "Course Controls", path: "/instructor/controls" },
-    "/instructor/contact": { label: "Contact", path: "/instructor/contact" },
-    "/instructor/assignment-builder": { label: "Assignments", path: "/instructor/assignments" },
-    "/instructor/roster": { label: "Roster", path: "/instructor/roster" },
-    "/instructor/profile": { label: "Profile & Preferences", path: "/instructor/profile" },
-    "/instructor/practice": { label: "Practice", path: "/instructor/practice" },
-    "/student/dashboard": { label: "Dashboard", path: "/student/dashboard" },
-    "/student/courses": { label: "My Courses", path: "/student/courses" },
-    "/student/assignments": { label: "Assignments", path: "/student/assignments" },
-    "/student/grades": { label: "Grades", path: "/student/grades" },
-    "/student/practice": { label: "Practice", path: "/student/practice" },
-    "/student/contact": { label: "Contact", path: "/student/contact" },
-    "/student/profile": { label: "Profile & Preferences", path: "/student/profile" },
-  };
-
-  return routes[pathname] || { label: "Dashboard", path: "/student/dashboard" };
-};
-
-const getCourseListPath = (pathname) => {
-  if (pathname.startsWith("/instructor/")) {
-    return "/instructor/courses";
-  }
-  return "/student/courses";
-};
-
-export default function Header() {
+export default function Header({ onSignOut }) {
   const location = useLocation();
-  const { courses, activeCourseId } = useCoursesState();
+  const { courses, activeCourseId, coursesPath, getBreadcrumbInfo, isSandbox: sandbox } = useAppRuntime();
   const layoutDispatch = useLayoutDispatch();
   const { isRulesReferenceOpen } = useLayoutState();
   const theme = useTheme();
   const isMobile = useMediaQuery(theme.breakpoints.down("md"));
-
   const activeCourse = courses.find((c) => c.id === activeCourseId);
   const pageInfo = getBreadcrumbInfo(location.pathname);
-  const courseListPath = getCourseListPath(location.pathname);
 
   return (
     <AppBar
@@ -98,48 +56,64 @@ export default function Header() {
           </IconButton>
         )}
         <Box
-          sx={{ flexGrow: 1, display: "flex", alignItems: "center", gap: 1 }}
+          sx={{ flexGrow: 1, display: "flex", alignItems: "center", gap: 1.5, minWidth: 0 }}
         >
-          {activeCourse ? (
-            <Breadcrumbs
-              separator={<ChevronRight size={16} />}
-              sx={{
-                "& .MuiBreadcrumbs-separator": {
-                  mx: 1,
-                  color: "text.disabled",
-                },
-              }}
-            >
-              <Link
-                component={RouterLink}
-                to={courseListPath}
-                underline="hover"
-                color="text.primary"
-                variant="body1"
-                sx={{ fontWeight: 600 }}
+          <Box sx={{ minWidth: 0, display: "flex", alignItems: "center" }}>
+            {activeCourse ? (
+              <Breadcrumbs
+                separator={<ChevronRight size={16} />}
+                sx={{
+                  "& .MuiBreadcrumbs-separator": {
+                    mx: 1,
+                    color: "text.disabled",
+                  },
+                }}
               >
-                {activeCourse.code}
-              </Link>
-              <Link
-                component={RouterLink}
-                to={pageInfo.path}
-                underline="hover"
-                color="text.secondary"
+                <Link
+                  component={RouterLink}
+                  to={coursesPath}
+                  underline="hover"
+                  color="text.primary"
+                  variant="body1"
+                  sx={{ fontWeight: 600 }}
+                >
+                  {activeCourse.code}
+                </Link>
+                <Link
+                  component={RouterLink}
+                  to={pageInfo.path}
+                  underline="hover"
+                  color="text.secondary"
+                  variant="body1"
+                >
+                  {pageInfo.label}
+                </Link>
+              </Breadcrumbs>
+            ) : (
+              <Typography
                 variant="body1"
+                sx={{
+                  fontWeight: 600,
+                  color: "text.primary",
+                }}
               >
                 {pageInfo.label}
-              </Link>
-            </Breadcrumbs>
-          ) : (
-            <Typography
-              variant="body1"
+              </Typography>
+            )}
+          </Box>
+          {sandbox && (
+            <Button
+              onClick={onSignOut}
+              variant="outlined"
+              size="small"
+              startIcon={<ArrowBackIcon />}
               sx={{
-                fontWeight: 600,
-                color: "text.primary",
+                textTransform: 'none',
+                flexShrink: 0,
               }}
             >
-              {pageInfo.label}
-            </Typography>
+              Exit demo
+            </Button>
           )}
         </Box>
         <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>

--- a/src/components/layout/ShellFrame.jsx
+++ b/src/components/layout/ShellFrame.jsx
@@ -1,0 +1,106 @@
+import { Box, useMediaQuery, useTheme } from "@mui/material";
+import { useEffect, useRef } from "react";
+import Header from "./Header.jsx";
+import Sidebar from "./Sidebar.jsx";
+import RulesReference from "../ui/RulesReference.jsx";
+import AccountSettingsDialog from "../ui/AccountSettingsDialog.jsx";
+import { useLayoutState } from "../../context/LayoutContext.jsx";
+
+export default function ShellFrame({
+  children,
+  location,
+  sidebarStructure,
+  onSignOut,
+  onOpenSettings,
+  showAccountSettings = false,
+  isAccountSettingsOpen = false,
+  onCloseAccountSettings,
+}) {
+  const { isRulesReferenceOpen } = useLayoutState();
+  const mainContentRef = useRef(null);
+  const theme = useTheme();
+  const isLargeScreen = useMediaQuery(theme.breakpoints.up("lg"));
+  const hasDesktopPointer = useMediaQuery("(hover: hover) and (pointer: fine)");
+  const isDesktopRulebookLayout = isLargeScreen && hasDesktopPointer;
+  const shouldShiftShellForRulebook = isDesktopRulebookLayout && isRulesReferenceOpen;
+
+  useEffect(() => {
+    const timer = setTimeout(() => {
+      window.scrollTo({
+        top: 0,
+        left: 0,
+        behavior: "smooth",
+      });
+
+      if (mainContentRef.current) {
+        mainContentRef.current.scrollTo({
+          top: 0,
+          left: 0,
+          behavior: "smooth",
+        });
+      }
+    }, 0);
+
+    return () => clearTimeout(timer);
+  }, [location.pathname]);
+
+  return (
+    <Box
+      sx={{
+        display: "flex",
+        minHeight: "100vh",
+        minWidth: 0,
+        height: { xs: "auto", md: "100dvh" },
+        overflow: { xs: "visible", md: "hidden" },
+      }}
+    >
+      <Box
+        sx={{
+          display: "flex",
+          flexGrow: 1,
+          minWidth: 0,
+          minHeight: { xs: "auto", md: 0 },
+          overflow: { xs: "visible", md: "hidden" },
+          transform: shouldShiftShellForRulebook ? "translateX(16px)" : "translateX(0)",
+          transition: (t) =>
+            t.transitions.create("transform", {
+              duration: t.transitions.duration.shorter,
+            }),
+        }}
+      >
+        <Sidebar
+          structure={sidebarStructure}
+          location={location}
+          onSignOut={onSignOut}
+          onOpenSettings={onOpenSettings}
+        />
+        <Box sx={{ display: "flex", flexDirection: "column", flexGrow: 1, minWidth: 0 }}>
+          <Header onSignOut={onSignOut} />
+          <Box
+            component="main"
+            ref={mainContentRef}
+            sx={{
+              flexGrow: 1,
+              p: 3,
+              pt: /\/assignment\/[^/]+$/.test(location.pathname) ? 2 : 3,
+              backgroundColor: "background.default",
+              minHeight: { xs: "100vh", md: 0 },
+              overflow: "auto",
+              overflowX: "hidden",
+              minWidth: 0,
+            }}
+          >
+            {children}
+          </Box>
+        </Box>
+      </Box>
+      {showAccountSettings && (
+        <AccountSettingsDialog
+          open={isAccountSettingsOpen}
+          onClose={onCloseAccountSettings}
+        />
+      )}
+      <RulesReference />
+    </Box>
+  );
+}

--- a/src/components/layout/Sidebar.jsx
+++ b/src/components/layout/Sidebar.jsx
@@ -26,9 +26,9 @@ import {
   toggleSidebar,
   setSidebar,
 } from "../../context/LayoutContext.jsx";
-import { useAuthState } from "../../context/AuthContext.jsx";
 import SidebarLink from "./SidebarLink.jsx";
 import CourseSelector from "../ui/CourseSelector.jsx";
+import { useAppRuntime } from "../../hooks/useAppRuntime.js";
 
 const DRAWER_WIDTH = 240;
 
@@ -36,13 +36,12 @@ export default function Sidebar({ structure, location, onSignOut, onOpenSettings
   const theme = useTheme();
   const isMobile = useMediaQuery(theme.breakpoints.down("md"));
   const { isSidebarOpened, sidebarHoverEnabled } = useLayoutState();
-  const { user } = useAuthState();
+  const { user: activeUser, isSandbox: sandbox } = useAppRuntime();
   const layoutDispatch = useLayoutDispatch();
   const [isPermanent, setPermanent] = useState(true);
   const [profileMenu, setProfileMenu] = useState(null);
   const [isHovering, setIsHovering] = useState(false);
   const [manuallyOpened, setManuallyOpened] = useState(false);
-
   useEffect(() => {
     const handleResize = () => {
       const isSmallScreen = window.innerWidth < theme.breakpoints.values.md;
@@ -86,14 +85,14 @@ export default function Sidebar({ structure, location, onSignOut, onOpenSettings
 
   // Get user's initials for avatar
   const getUserInitials = () => {
-    if (!user?.username) return "U";
-    return user.username.substring(0, 2).toUpperCase();
+    if (!activeUser?.username) return "U";
+    return activeUser.username.substring(0, 2).toUpperCase();
   };
 
   // Get display name
   const getDisplayName = () => {
-    if (!user?.username) return "User";
-    return user.username;
+    if (!activeUser?.username) return "User";
+    return activeUser.username;
   };
 
   return (
@@ -241,21 +240,23 @@ export default function Sidebar({ structure, location, onSignOut, onOpenSettings
             transformOrigin={{ vertical: "bottom", horizontal: "left" }}
             slotProps={{ paper: { sx: { '& .MuiListItemText-primary': { fontSize: '1rem' } } } }}
           >
-          <MenuItem
-            onClick={() => {
-              onOpenSettings?.();
-              setProfileMenu(null);
-            }}
-          >
-            Settings
-          </MenuItem>
+          {onOpenSettings && (
+            <MenuItem
+              onClick={() => {
+                onOpenSettings?.();
+                setProfileMenu(null);
+              }}
+            >
+              Settings
+            </MenuItem>
+          )}
           <MenuItem
             onClick={() => {
               onSignOut?.();
               setProfileMenu(null);
             }}
           >
-            Sign Out
+            {sandbox ? "Exit demo" : "Sign Out"}
           </MenuItem>
           </Menu>
         </Box>

--- a/src/components/ui/CourseSelector.jsx
+++ b/src/components/ui/CourseSelector.jsx
@@ -18,35 +18,22 @@ import {
   CheckCircle as CheckCircleIcon,
 } from "@mui/icons-material";
 import { useNavigate, useLocation } from "react-router-dom";
-import { useAuthState } from "../../context/AuthContext";
-import { isInstructorRole } from "../../utils/auth.js";
-import {
-  useCoursesState,
-  useCoursesDispatch,
-  setActiveCourse,
-} from "../../context/CoursesContext";
+import { useAppRuntime } from "../../hooks/useAppRuntime.js";
 
 export default function CourseSelector({ isSidebarOpened }) {
   const [anchorEl, setAnchorEl] = useState(null);
-  const { user } = useAuthState();
-  const { courses, activeCourseId } = useCoursesState();
-  const dispatch = useCoursesDispatch();
+  const {
+    courses: courseList,
+    activeCourseId,
+    coursesPath,
+    dashboardPath,
+    courseActions,
+  } = useAppRuntime();
   const navigate = useNavigate();
   const location = useLocation();
-
-  const isInstructor = location.pathname.startsWith("/instructor")
-    ? true
-    : location.pathname.startsWith("/student")
-    ? false
-    : isInstructorRole(user?.role);
-  const coursesPath = isInstructor ? "/instructor/courses" : "/student/courses";
-  const dashboardPath = isInstructor
-    ? "/instructor/dashboard"
-    : "/student/dashboard";
-
-  const activeCourse = courses.find((c) => c.id === activeCourseId);
-  const currentCourses = courses.filter((c) => c.status === "current");
-  const pastCourses = courses.filter((c) => c.status === "past");
+  const activeCourse = courseList.find((c) => c.id === activeCourseId);
+  const currentCourses = courseList.filter((c) => c.status === "current");
+  const pastCourses = courseList.filter((c) => c.status === "past");
 
   const handleClick = (event) => {
     setAnchorEl(event.currentTarget);
@@ -67,7 +54,7 @@ export default function CourseSelector({ isSidebarOpened }) {
   }, [isSidebarOpened]);
 
   const handleSelectCourse = (courseId) => {
-    setActiveCourse(dispatch, courseId);
+    courseActions.setActiveCourse?.(courseId);
     handleClose();
 
     // Navigate to dashboard when selecting a course
@@ -267,7 +254,7 @@ export default function CourseSelector({ isSidebarOpened }) {
             </>
           )}
 
-          {courses.length === 0 && (
+          {courseList.length === 0 && (
             <Box sx={{ px: 2, py: 3, textAlign: "center" }}>
               <Typography color="text.secondary" sx={{ fontSize: "1rem" }}>
                 No courses available
@@ -519,10 +506,10 @@ export default function CourseSelector({ isSidebarOpened }) {
           </>
         )}
 
-        {courses.length === 0 && (
-          <Box sx={{ px: 2, py: 3, textAlign: "center" }}>
-            <Typography color="text.secondary" sx={{ fontSize: "1rem" }}>
-              No courses available
+          {courseList.length === 0 && (
+            <Box sx={{ px: 2, py: 3, textAlign: "center" }}>
+              <Typography color="text.secondary" sx={{ fontSize: "1rem" }}>
+                No courses available
             </Typography>
           </Box>
         )}

--- a/src/components/ui/StudentProfileModal.jsx
+++ b/src/components/ui/StudentProfileModal.jsx
@@ -36,7 +36,6 @@ import {
   CheckCircle,
   AlertCircle,
 } from "lucide-react";
-import { useCoursesState } from "../../context/CoursesContext";
 import {
   getLetterGrade,
   getGradeColorVariant,
@@ -46,7 +45,7 @@ import {
 import { formatDate } from "../../utils/formatting.js";
 import { formatEasternFromIso, formatEasternDateTime } from "../../utils/easternTime.js";
 import { MetricCard } from "./MetricCard";
-import { fetchJson } from "../../utils/api.js";
+import { useAppRuntime } from "../../hooks/useAppRuntime.js";
 
 // Helper function to calculate average
 function calculateAverage(grades) {
@@ -90,7 +89,8 @@ export default function StudentProfileModal({
   onToggleRole,
 }) {
   const theme = useTheme();
-  const { courses, activeCourseId } = useCoursesState();
+  const { courseState, courseActions } = useAppRuntime();
+  const { courses, activeCourseId } = courseState;
   const activeCourse = courses.find((c) => c.id === activeCourseId);
   const gradingScale = activeCourse?.gradingScale || getDefaultGradingScale();
 
@@ -126,16 +126,13 @@ export default function StudentProfileModal({
 
   // hydrate accommodations when the modal opens
   useEffect(() => {
-    const courseId = Number(activeCourseId);
-    if (!open || !student || !Number.isFinite(courseId) || !canEditAccommodations) return;
+    if (!open || !student || !canEditAccommodations) return;
     let isMounted = true;
     const load = async () => {
       setAccommodationLoading(true);
       setAccommodationError("");
       try {
-        const rows = await fetchJson(
-          `/api/instructor/courses/${courseId}/accommodations`
-        );
+        const rows = await courseActions.getAccommodations?.(activeCourseId, student.id);
         if (!isMounted) return;
         const record = (rows || []).find((r) => r.user_id === student.id);
         const lateDaysValue = Number.isFinite(Number(record?.extra_late_days))
@@ -154,17 +151,14 @@ export default function StudentProfileModal({
     return () => {
       isMounted = false;
     };
-  }, [open, student, activeCourseId, canEditAccommodations]);
+  }, [open, student, activeCourseId, canEditAccommodations, courseActions]);
 
   useEffect(() => {
-    const courseId = Number(activeCourseId);
-    if (!open || !student || !Number.isFinite(courseId) || !canEditAccommodations) return;
+    if (!open || !student || !canEditAccommodations) return;
     let isMounted = true;
     const load = async () => {
       try {
-        const rows = await fetchJson(
-          `/api/instructor/courses/${courseId}/deadlines/${student.id}`
-        );
+        const rows = await courseActions.getDeadlines?.(activeCourseId, student.id);
         if (!isMounted) return;
         const map = {};
         (rows || []).forEach((row) => {
@@ -181,7 +175,7 @@ export default function StudentProfileModal({
     return () => {
       isMounted = false;
     };
-  }, [open, student, activeCourseId, canEditAccommodations]);
+  }, [open, student, activeCourseId, canEditAccommodations, courseActions]);
 
   // default extension picker to the assignment due date
   useEffect(() => {
@@ -203,25 +197,19 @@ export default function StudentProfileModal({
 
   // store course level accommodations for this student
   const handleSaveAccommodation = async () => {
-    const courseId = Number(activeCourseId);
-    if (!Number.isFinite(courseId) || !student) return;
+    if (!student) return;
     setAccommodationSaved(false);
     setAccommodationError("");
     setAccommodationLoading(true);
     try {
-      await fetchJson(`/api/instructor/courses/${courseId}/accommodations`, {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({
-          user_id: student.id,
-          extra_late_days: Math.max(0, parseInt(extraLateDays || "0", 10) || 0),
-          late_penalty_waived: Boolean(latePenaltyWaived),
-        }),
-      });
+      const payload = {
+        user_id: student.id,
+        extra_late_days: Math.max(0, parseInt(extraLateDays || "0", 10) || 0),
+        late_penalty_waived: Boolean(latePenaltyWaived),
+      };
+      await courseActions.saveAccommodations?.(activeCourseId, student.id, payload);
       try {
-        const rows = await fetchJson(
-          `/api/instructor/courses/${courseId}/deadlines/${student.id}`
-        );
+        const rows = await courseActions.getDeadlines?.(activeCourseId, student.id);
         const map = {};
         (rows || []).forEach((row) => {
           if (!row?.assignment_id) return;
@@ -265,22 +253,9 @@ export default function StudentProfileModal({
     }
     setExtensionSaving(true);
     try {
-      await fetchJson(
-        `/api/instructor/assignments/${assignmentId}/extensions`,
-        {
-          method: "POST",
-          headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({
-            user_id: student.id,
-            extended_due_date: iso,
-          }),
-        }
-      );
+      await courseActions.saveDeadline?.(activeCourseId, assignmentId, student.id, iso);
       try {
-        const courseId = Number(activeCourseId);
-        const rows = await fetchJson(
-          `/api/instructor/courses/${courseId}/deadlines/${student.id}`
-        );
+        const rows = await courseActions.getDeadlines?.(activeCourseId, student.id);
         const map = {};
         (rows || []).forEach((row) => {
           if (!row?.assignment_id) return;

--- a/src/components/ui/dashboard/AssignmentDetailModal.jsx
+++ b/src/components/ui/dashboard/AssignmentDetailModal.jsx
@@ -32,8 +32,6 @@ import {
 
 import { useNavigate, useLocation } from "react-router-dom";
 import {
-  useCoursesState,
-  useCoursesDispatch,
   calculateAssignmentAverage,
 } from "../../../context/CoursesContext";
 import { MetricCard } from "../MetricCard";
@@ -41,6 +39,7 @@ import { GradeDistributionChart } from "./GradeDistributionChart";
 import StudentSubmissionsTable from "./StudentSubmissionsTable";
 import GradeBreakdown from "./GradeBreakdown";
 import { formatEasternDateTime } from "../../../utils/easternTime.js";
+import { useAppRuntime } from "../../../hooks/useAppRuntime.js";
 
 // Helper functions
 function getLetterGrade(grade) {
@@ -64,11 +63,10 @@ export default function AssignmentDetailModal({ open, onClose, assignmentId }) {
   const [activeTab, setActiveTab] = useState(0);
   const navigate = useNavigate();
   const location = useLocation();
-  const dispatch = useCoursesDispatch();
+  const { courseState, courseActions, assignmentPath } = useAppRuntime();
 
   // Pull data from context
-  const { activeCourseId, assignmentsByCourse, gradebookByCourse, courses } =
-    useCoursesState();
+  const { activeCourseId, assignmentsByCourse, gradebookByCourse, courses } = courseState;
 
   // Get current course and assignment data
   const activeCourse = courses.find((c) => c.id === activeCourseId);
@@ -155,29 +153,15 @@ export default function AssignmentDetailModal({ open, onClose, assignmentId }) {
 
   // Action handlers using context dispatch
   const handleToggleLock = () => {
-    const updatedAssignments = assignments.map((a) =>
-      a.id === assignment.id ? { ...a, isLocked: !a.isLocked } : a
-    );
-    dispatch({
-      type: "SET_ASSIGNMENTS",
-      courseId: activeCourseId,
-      payload: updatedAssignments,
-    });
+    courseActions.toggleAssignmentLock?.(activeCourseId, assignment.id, assignment);
   };
 
   const handleTogglePublish = () => {
-    const updatedAssignments = assignments.map((a) =>
-      a.id === assignment.id ? { ...a, isPublished: !a.isPublished } : a
-    );
-    dispatch({
-      type: "SET_ASSIGNMENTS",
-      courseId: activeCourseId,
-      payload: updatedAssignments,
-    });
+    courseActions.toggleAssignmentPublish?.(activeCourseId, assignment.id, assignment);
   };
 
   const handleOpenAssignment = () => {
-    navigate(`/instructor/assignment/${assignment.id}`, {
+    navigate(assignmentPath(assignment.id), {
       state: { returnTo: location.pathname },
     });
     onClose();

--- a/src/components/ui/dashboard/AssignmentOverviewTable.jsx
+++ b/src/components/ui/dashboard/AssignmentOverviewTable.jsx
@@ -15,13 +15,13 @@ import {
 } from "@mui/material";
 import { CheckCircle } from "lucide-react";
 import AssignmentDetailModal from "./AssignmentDetailModal";
-import { useCoursesState } from "../../../context/CoursesContext";
 import {
   getLetterGrade,
   getGradeColorVariant,
   getDefaultGradingScale,
 } from "../../../utils/gradingUtils";
 import { formatEasternDateTime } from "../../../utils/easternTime.js";
+import { useAppRuntime } from "../../../hooks/useAppRuntime.js";
 
 export const AssignmentOverviewTable = ({
   assignments: assignmentsProp,
@@ -30,8 +30,8 @@ export const AssignmentOverviewTable = ({
   totalPossible: totalPossibleProp,
   completionRate: completionRateProp,
 } = {}) => {
-  const { courses, activeCourseId, assignmentsByCourse, gradebookByCourse } =
-    useCoursesState();
+  const { courseState } = useAppRuntime();
+  const { courses, activeCourseId, assignmentsByCourse, gradebookByCourse } = courseState;
   const activeCourse = courses.find((c) => c.id === activeCourseId);
 
   const assignments = assignmentsProp ?? (assignmentsByCourse[activeCourseId] || []);

--- a/src/components/ui/dashboard/StudentsAtRiskTable.jsx
+++ b/src/components/ui/dashboard/StudentsAtRiskTable.jsx
@@ -10,15 +10,16 @@ import {
   Chip,
   alpha,
 } from "@mui/material";
-import { useCoursesState } from "../../../context/CoursesContext";
 import {
   getLetterGrade,
   getGradeColorVariant,
   getDefaultGradingScale,
 } from "../../../utils/gradingUtils";
+import { useAppRuntime } from "../../../hooks/useAppRuntime.js";
 
 export const StudentsAtRiskTable = ({ students, assignments }) => {
-  const { courses, activeCourseId } = useCoursesState();
+  const { courseState } = useAppRuntime();
+  const { courses, activeCourseId } = courseState;
   const activeCourse = courses.find((c) => c.id === activeCourseId);
   const gradingScale = activeCourse?.gradingScale || getDefaultGradingScale();
 

--- a/src/components/ui/gradebook/GradebookTable.jsx
+++ b/src/components/ui/gradebook/GradebookTable.jsx
@@ -13,7 +13,6 @@ import {
   Tooltip,
   alpha,
 } from "@mui/material";
-import { useCoursesState } from "../../../context/CoursesContext";
 import {
   getLetterGrade,
   getGradeColorVariant,
@@ -21,6 +20,7 @@ import {
   getDefaultGradingScale,
 } from "../../../utils/gradingUtils";
 import StudentProfileModal from "../StudentProfileModal";
+import { useAppRuntime } from "../../../hooks/useAppRuntime.js";
 
 // Helper function to calculate average
 function calculateAverage(grades) {
@@ -54,7 +54,8 @@ export default function GradebookTable({
   sortDirection,
   handleSort,
 }) {
-  const { courses, activeCourseId } = useCoursesState();
+  const { courseState } = useAppRuntime();
+  const { courses, activeCourseId } = courseState;
   const activeCourse = courses.find((c) => c.id === activeCourseId);
   const gradingScale = activeCourse?.gradingScale || getDefaultGradingScale();
   const isInstructor = activeCourse?.role === "instructor";

--- a/src/context/AppRuntimeContext.jsx
+++ b/src/context/AppRuntimeContext.jsx
@@ -1,0 +1,19 @@
+import { createContext, useContext } from 'react'
+
+const AppRuntimeContext = createContext(null)
+
+export function AppRuntimeProvider({ value, children }) {
+  return (
+    <AppRuntimeContext.Provider value={value}>
+      {children}
+    </AppRuntimeContext.Provider>
+  )
+}
+
+export function useAppRuntimeContext() {
+  const context = useContext(AppRuntimeContext)
+  if (!context) {
+    throw new Error('useAppRuntime must be used within an AppRuntimeProvider')
+  }
+  return context
+}

--- a/src/hooks/useAppRuntime.js
+++ b/src/hooks/useAppRuntime.js
@@ -1,0 +1,5 @@
+import { useAppRuntimeContext } from '../context/AppRuntimeContext.jsx'
+
+export function useAppRuntime() {
+  return useAppRuntimeContext()
+}

--- a/src/pages/Assignments.jsx
+++ b/src/pages/Assignments.jsx
@@ -8,6 +8,7 @@ import ActivityAccordion from '../components/ui/ActivityAccordion.jsx'
 import { ACTIVITY_TYPES } from '../placeholder/courseActivities.js'
 import { formatDateTime } from '../utils/formatting.js'
 import { parseDueDateAsEastern } from '../utils/easternTime.js'
+import { compareSubchapterLabels, sortAssignmentsBySubchapter } from '../utils/assignmentSort.js'
 import { API_CONFIG, fetchJson, getActiveUserId } from '../utils/api.js'
 import { useAppRuntime } from '../hooks/useAppRuntime.js'
 
@@ -34,11 +35,26 @@ const buildCourseStructure = (assignments, sectionTitle) => {
     chapters.set(chapterLabel, chapterEntry)
   })
 
+  const compareLabels = (a, b) => a.localeCompare(b, undefined, { numeric: true, sensitivity: 'base' })
+  const chapterValue = (label) => {
+    const match = /^Chapter\s+(\d+)/i.exec(label)
+    return match ? Number(match[1]) : null
+  }
+
   return Array.from(chapters.entries())
+    .sort(([labelA], [labelB]) => {
+      const aNum = chapterValue(labelA)
+      const bNum = chapterValue(labelB)
+      if (aNum !== null && bNum !== null) return aNum - bNum
+      if (aNum !== null) return -1
+      if (bNum !== null) return 1
+      return compareLabels(labelA, labelB)
+    })
     .map(([chapterLabel, subMap]) => ({
       id: chapterLabel,
       title: chapterLabel,
       subchapters: Array.from(subMap.entries())
+        .sort(([a], [b]) => compareSubchapterLabels(a, b))
         .map(([subLabel, items]) => ({
           id: `${chapterLabel}-${subLabel}`,
           title: subLabel,
@@ -119,7 +135,10 @@ export default function Assignments() {
   const isLoadingAssignments = sandbox ? false : (assignmentsQuery.isPending || gradesQuery.isPending)
 
   const gradedAssignments = useMemo(
-    () => (assignments || []).filter((a) => a.kind !== 'practice'),
+    () =>
+      sortAssignmentsBySubchapter(
+        (assignments || []).filter((a) => a.kind !== 'practice')
+      ),
     [assignments]
   )
 

--- a/src/pages/Assignments.jsx
+++ b/src/pages/Assignments.jsx
@@ -1,16 +1,15 @@
 import { useEffect, useMemo, useCallback, useState } from 'react'
 import { useNavigate } from 'react-router-dom'
 import { useQuery } from '@tanstack/react-query'
-import { Box, Tabs, Tab, Typography, CardContent, Chip, Stack, LinearProgress } from '@mui/material'
+import { Box, Tabs, Tab, Typography, CardContent, Chip, Stack } from '@mui/material'
 import LockIcon from '@mui/icons-material/Lock'
 import ThemedCard from '../components/ui/ThemedCard.jsx'
 import ActivityAccordion from '../components/ui/ActivityAccordion.jsx'
 import { ACTIVITY_TYPES } from '../placeholder/courseActivities.js'
 import { formatDateTime } from '../utils/formatting.js'
 import { parseDueDateAsEastern } from '../utils/easternTime.js'
-import { compareSubchapterLabels, sortAssignmentsBySubchapter } from '../utils/assignmentSort.js'
 import { API_CONFIG, fetchJson, getActiveUserId } from '../utils/api.js'
-import { useCoursesState } from '../context/CoursesContext.jsx'
+import { useAppRuntime } from '../hooks/useAppRuntime.js'
 
 const buildCourseStructure = (assignments, sectionTitle) => {
   const chapters = new Map()
@@ -30,33 +29,16 @@ const buildCourseStructure = (assignments, sectionTitle) => {
       type: ACTIVITY_TYPES.HOMEWORK,
       worksheet: { id: assignment.id, proofs: [] },
       isLocked: assignment.is_locked ?? assignment.isLocked ?? false,
-      questionCount: Number(assignment.question_count) || 0,
-      answeredCount: Number(assignment.answered_count) || 0,
     })
     chapterEntry.set(subLabel, items)
     chapters.set(chapterLabel, chapterEntry)
   })
 
-  const compareLabels = (a, b) => a.localeCompare(b, undefined, { numeric: true, sensitivity: 'base' })
-  const chapterValue = (label) => {
-    const match = /^Chapter\s+(\d+)/i.exec(label)
-    return match ? Number(match[1]) : null
-  }
-
   return Array.from(chapters.entries())
-    .sort(([labelA], [labelB]) => {
-      const aNum = chapterValue(labelA)
-      const bNum = chapterValue(labelB)
-      if (aNum !== null && bNum !== null) return aNum - bNum
-      if (aNum !== null) return -1
-      if (bNum !== null) return 1
-      return compareLabels(labelA, labelB)
-    })
     .map(([chapterLabel, subMap]) => ({
       id: chapterLabel,
       title: chapterLabel,
       subchapters: Array.from(subMap.entries())
-        .sort(([a], [b]) => compareSubchapterLabels(a, b))
         .map(([subLabel, items]) => ({
           id: `${chapterLabel}-${subLabel}`,
           title: subLabel,
@@ -74,11 +56,19 @@ function TabPanel({ children, value, index }) {
 }
 
 export default function Assignments() {
-  const { activeCourseId } = useCoursesState()
+  const {
+    isSandbox: sandbox,
+    assignmentsPath,
+    assignmentPath,
+    storageScope,
+    sandbox: sandboxData,
+    user,
+    activeCourseId,
+  } = useAppRuntime()
   const courseId = activeCourseId ?? API_CONFIG.courseId
   const navigate = useNavigate()
-  const courseIdForApi = activeCourseId ?? null
-  const userId = getActiveUserId()
+  const courseIdForApi = sandbox ? null : (activeCourseId ?? null)
+  const userId = sandbox ? user.id : getActiveUserId()
   const tabStorageKey = useMemo(() => {
     const suffix = courseIdForApi ? `course-${courseIdForApi}` : 'default'
     return `assignments:last-tab:${suffix}`
@@ -90,14 +80,20 @@ export default function Assignments() {
     return parts.join(':')
   }, [courseIdForApi, userId])
 
-  const readStoredTab = useCallback(() => {
+  const getRouteStorage = useCallback(() => {
     if (typeof window === 'undefined') return null
-    const raw = window.localStorage.getItem(tabStorageKey)
+    return storageScope === 'session' ? window.sessionStorage : window.localStorage
+  }, [storageScope])
+
+  const readStoredTab = useCallback(() => {
+    const storage = getRouteStorage()
+    if (!storage) return null
+    const raw = storage.getItem(tabStorageKey)
     const parsed = raw === null ? null : Number(raw)
     if (!Number.isFinite(parsed)) return null
     if (parsed < 0 || parsed > 2) return null
     return parsed
-  }, [tabStorageKey])
+  }, [getRouteStorage, tabStorageKey])
 
   const [tabValue, setTabValue] = useState(() => readStoredTab() ?? 0)
 
@@ -109,30 +105,27 @@ export default function Assignments() {
   const assignmentsQuery = useQuery({
     queryKey: ['course-assignments', courseIdForApi],
     queryFn: () => fetchJson(`/api/courses/${courseIdForApi}/assignments`),
-    enabled: !!courseIdForApi,
+    enabled: !sandbox && !!courseIdForApi,
   })
 
   const gradesQuery = useQuery({
     queryKey: ['user-grades', userId],
     queryFn: () => fetchJson(`/api/users/${userId}/grades`),
-    enabled: !!userId,
+    enabled: !sandbox && !!userId,
   })
 
-  const assignments = assignmentsQuery.data ?? []
-  const grades = gradesQuery.data ?? []
-  const isLoadingAssignments = assignmentsQuery.isPending || gradesQuery.isPending
+  const assignments = sandbox ? sandboxData.assignments : (assignmentsQuery.data ?? [])
+  const grades = sandbox ? sandboxData.grades : (gradesQuery.data ?? [])
+  const isLoadingAssignments = sandbox ? false : (assignmentsQuery.isPending || gradesQuery.isPending)
 
   const gradedAssignments = useMemo(
-    () =>
-      sortAssignmentsBySubchapter(
-        (assignments || []).filter((a) => a.kind !== 'practice')
-      ),
+    () => (assignments || []).filter((a) => a.kind !== 'practice'),
     [assignments]
   )
 
   const courseStructure = useMemo(
-    () => (courseIdForApi ? buildCourseStructure(gradedAssignments, 'Assignments') : []),
-    [courseIdForApi, gradedAssignments]
+    () => ((sandbox || courseIdForApi) ? buildCourseStructure(gradedAssignments, 'Assignments') : []),
+    [sandbox, courseIdForApi, gradedAssignments]
   )
 
   const completedAssignments = useMemo(() => {
@@ -206,15 +199,16 @@ export default function Assignments() {
 
   const handleTabChange = (e, newValue) => {
     setTabValue(newValue)
-    if (typeof window !== 'undefined') {
-      window.localStorage.setItem(tabStorageKey, String(newValue))
+    const storage = getRouteStorage()
+    if (storage) {
+      storage.setItem(tabStorageKey, String(newValue))
     }
   }
 
   const handleActivityClick = (activity) => {
     if (activity.worksheet) {
-      navigate(`/student/assignment/${activity.worksheet.id}`, {
-        state: { returnTo: '/student/assignments' }
+      navigate(assignmentPath(activity.worksheet.id), {
+        state: { returnTo: assignmentsPath }
       })
     }
   }
@@ -227,27 +221,18 @@ export default function Assignments() {
     const accommodationDueLabel = policy?.accommodation_due_at
       ? formatDateTime(policy.accommodation_due_at)
       : null
-    const totalQuestions = Number(activity.questionCount) || 0
-    const completedQuestions = Math.min(Number(activity.answeredCount) || 0, totalQuestions)
-    const completionValue = totalQuestions > 0 ? (completedQuestions / totalQuestions) * 100 : 0
     return (
     <ThemedCard
       key={activity.id}
       sx={{ cursor: 'pointer', '&:hover': { boxShadow: 4 } }}
       onClick={() => handleActivityClick(activity)}
     >
-      <CardContent sx={{ p: 2, '&:last-child': { pb: 2 } }}>
-        <Box
-          sx={{
-            display: 'grid',
-            gridTemplateColumns: {
-              xs: '1fr',
-              md: 'minmax(0, 1fr) clamp(240px, 28vw, 360px)',
-            },
-            columnGap: { xs: 0, md: 4 },
-            rowGap: 2,
-            alignItems: 'start',
-          }}
+      <CardContent sx={{ pl: 0, pr: 2, pt: 2, pb: 2, '&:last-child': { pb: 2 } }}>
+        <Stack
+          direction={{ xs: 'column', sm: 'row' }}
+          justifyContent="space-between"
+          alignItems={{ xs: 'flex-start', sm: 'flex-start' }}
+          spacing={2}
         >
           <Box sx={{ flex: 1, minWidth: 0 }}>
             <Stack direction="row" spacing={1} alignItems="center" sx={{ mb: 1 }}>
@@ -258,87 +243,51 @@ export default function Assignments() {
                 <LockIcon sx={{ fontSize: '1.25rem', color: 'text.secondary', flexShrink: 0 }} />
               )}
             </Stack>
-            {activity.description && (
-              <Typography variant="body2" color="text.secondary" sx={{ wordBreak: 'break-word' }}>
-                {activity.description}
+                  {activity.description && (
+                    <Typography variant="body2" color="text.secondary" sx={{ wordBreak: 'break-word' }}>
+                      {activity.description}
               </Typography>
             )}
           </Box>
-          <Stack spacing={0.75} alignItems={{ xs: 'flex-start', md: 'flex-end' }} width="100%">
-            <Stack
-              direction="row"
-              spacing={1}
-              alignItems="center"
-              flexWrap={{ xs: 'wrap', md: 'nowrap' }}
-              justifyContent={{ xs: 'flex-start', md: 'flex-end' }}
-              sx={{ width: '100%' }}
-            >
-              {totalQuestions > 0 && (
-                <Stack
-                  direction="row"
-                  spacing={0.75}
-                  alignItems="center"
-                  sx={{
-                    minWidth: { xs: '100%', md: 'auto' },
-                    flex: { xs: '1 1 100%', md: '0 0 auto' },
-                    flexShrink: 0,
-                  }}
-                >
-                  <Box sx={{ width: { xs: '100%', md: 140 } }}>
-                    <LinearProgress
-                      variant="determinate"
-                      value={completionValue}
-                      aria-label={`Assignment completion: ${completedQuestions} of ${totalQuestions} complete`}
-                      sx={{
-                        height: 8,
-                        borderRadius: 999,
-                        bgcolor: 'action.hover',
-                        '& .MuiLinearProgress-bar': { borderRadius: 999 },
-                      }}
-                    />
-                  </Box>
-                  <Typography variant="body2" sx={{ color: 'text.primary', fontWeight: 600, whiteSpace: 'nowrap' }}>
-                    {completedQuestions}/{totalQuestions}
-                  </Typography>
-                </Stack>
-              )}
+          <Stack spacing={1} alignItems={{ xs: 'flex-start', sm: 'flex-end' }} width={{ xs: '100%', sm: 'auto' }}>
+            <Stack direction="row" spacing={1} alignItems="center" flexWrap="wrap">
               <Chip
                 label={activity.type === ACTIVITY_TYPES.HOMEWORK ? 'Homework' : activity.type === ACTIVITY_TYPES.QUIZ ? 'Quiz' : 'Exam'}
                 size="small"
                 color="primary"
                 variant="outlined"
               />
-              {activity.dueDate && !getCompletionStatus(activity.id) && parseDueDateAsEastern(activity.dueDate, activity.dueTime) < new Date() && (
+              {activity.dueDate && parseDueDateAsEastern(activity.dueDate, activity.dueTime) < new Date() && (
                 <Chip label="Past due" size="small" color="error" />
               )}
-              {showCompletionChip && getCompletionStatus(activity.id) && (
-                <Chip label="Completed" size="small" color="success" />
-              )}
             </Stack>
-            <Typography variant="body2" color="text.secondary" sx={{ width: '100%', textAlign: { xs: 'left', md: 'right' } }}>
+            <Typography variant="body2" color="text.secondary">
               {datePrefix}{formatDateTime(activity.dueDate) || 'No due date'}
             </Typography>
             {(extensionDueLabel || accommodationDueLabel) && (
-              <Stack spacing={0.25} alignItems={{ xs: 'flex-start', md: 'flex-end' }} sx={{ width: '100%' }}>
-              {extensionDueLabel && (
-                <Typography variant="caption" color="text.secondary" align="right">
-                  Extension: {extensionDueLabel}
-                </Typography>
-              )}
-              {accommodationDueLabel && (
-                <Typography variant="caption" color="text.secondary" align="right">
-                  Accommodation: {accommodationDueLabel}
-                </Typography>
-              )}
-            </Stack>
-          )}
+              <Stack spacing={0.25} alignItems="flex-end">
+                {extensionDueLabel && (
+                  <Typography variant="caption" color="text.secondary" align="right">
+                    Extension: {extensionDueLabel}
+                  </Typography>
+                )}
+                {accommodationDueLabel && (
+                  <Typography variant="caption" color="text.secondary" align="right">
+                    Accommodation: {accommodationDueLabel}
+                  </Typography>
+                )}
+              </Stack>
+            )}
             {policy?.late_penalty_waived && (
-              <Typography variant="caption" color="text.secondary" align="right" sx={{ width: '100%', textAlign: { xs: 'left', md: 'right' } }}>
+              <Typography variant="caption" color="text.secondary" align="right">
                 Late penalty waived
               </Typography>
             )}
+            {showCompletionChip && getCompletionStatus(activity.id) && (
+              <Chip label="Completed" size="small" color="success" />
+            )}
           </Stack>
-        </Box>
+        </Stack>
       </CardContent>
     </ThemedCard>
     )
@@ -354,8 +303,8 @@ export default function Assignments() {
       showExpandAll={showExpandAll}
       showCollapseAll={showCollapseAll}
       showExpandCollapseToggle={showExpandCollapseToggle}
-      defaultSubchapterExpanded
       persistKey={accordionStorageKey}
+      storage={storageScope}
       renderActivity={(activity, context) =>
         renderActivity(activity, context, datePrefix, showCompletionChip)
       }

--- a/src/pages/Assignments.jsx
+++ b/src/pages/Assignments.jsx
@@ -322,6 +322,7 @@ export default function Assignments() {
       showExpandAll={showExpandAll}
       showCollapseAll={showCollapseAll}
       showExpandCollapseToggle={showExpandCollapseToggle}
+      defaultSubchapterExpanded
       persistKey={accordionStorageKey}
       storage={storageScope}
       renderActivity={(activity, context) =>

--- a/src/pages/Courses.jsx
+++ b/src/pages/Courses.jsx
@@ -5,57 +5,46 @@ import {
   School as SchoolIcon,
   CheckCircle as CheckCircleIcon,
 } from "@mui/icons-material";
-import { useLocation, useNavigate } from "react-router-dom";
+import { useNavigate } from "react-router-dom";
 import { useEffect, useState } from "react";
-import { useAuthState } from "../context/AuthContext";
-import { isInstructorRole } from "../utils/auth.js";
-import {
-  useCoursesState,
-  useCoursesDispatch,
-  setActiveCourse,
-  initializeCourses,
-  addNewCourse,
-} from "../context/CoursesContext";
 import CreateCourseDialog from "../components/ui/courses/CreateCourseDialog";
 import CoursesHeader from "../components/ui/courses/CoursesHeader";
 import CoursesSection from "../components/ui/courses/CoursesSection";
 import CoursesEmptyState from "../components/ui/courses/CoursesEmptyState";
 import CourseCardSkeleton from "../components/ui/courses/CourseCardSkeleton";
+import { useAppRuntime } from "../hooks/useAppRuntime.js";
 
 export default function Courses() {
-  const { user } = useAuthState();
-  const { courses, loading, error, initialized } = useCoursesState();
-  const dispatch = useCoursesDispatch();
+  const {
+    courses: visibleCourses,
+    isSandbox: sandbox,
+    isInstructor,
+    dashboardPath,
+    courseState,
+    courseActions,
+  } = useAppRuntime();
+  const { loading, error, initialized } = courseState;
   const navigate = useNavigate();
-  const location = useLocation();
   const [createDialogOpen, setCreateDialogOpen] = useState(false);
-
-  const isInstructor = location.pathname.startsWith("/instructor")
-    ? true
-    : location.pathname.startsWith("/student")
-    ? false
-    : isInstructorRole(user?.role);
-  const dashboardPath = isInstructor
-    ? "/instructor/dashboard"
-    : "/student/dashboard";
+  const allowCreateCourse = !sandbox || isInstructor;
 
   useEffect(() => {
-    if (!initialized) {
-      initializeCourses(dispatch);
+    if (!sandbox && !initialized) {
+      courseActions.initializeCourses?.();
     }
-  }, [initialized, dispatch]);
+  }, [sandbox, initialized, courseActions]);
 
-  const currentCourses = courses.filter((c) => c.status === "current");
-  const pastCourses = courses.filter((c) => c.status === "past");
+  const currentCourses = visibleCourses.filter((c) => c.status === "current");
+  const pastCourses = visibleCourses.filter((c) => c.status === "past");
 
   const handleSelectCourse = (courseId) => {
-    setActiveCourse(dispatch, courseId);
+    courseActions.setActiveCourse?.(courseId);
     navigate(dashboardPath);
   };
 
   const handleCreateCourse = async (courseData) => {
     try {
-      await addNewCourse(dispatch, courseData);
+      await courseActions.addNewCourse?.(courseData);
       navigate(dashboardPath);
     } catch (error) {
       console.error("Error creating course:", error);
@@ -67,7 +56,7 @@ export default function Courses() {
   };
 
   // Error state
-  if (error) {
+  if (!sandbox && error) {
     return (
       <Box>
         <Typography variant="h4" sx={{ mb: 4, fontWeight: 600 }}>
@@ -80,7 +69,7 @@ export default function Courses() {
             <Typography
               variant="button"
               sx={{ cursor: "pointer", textDecoration: "underline" }}
-              onClick={() => initializeCourses(dispatch)}
+              onClick={() => courseActions.initializeCourses?.()}
             >
               Retry
             </Typography>
@@ -104,10 +93,10 @@ export default function Courses() {
       />
 
       {/* Loading progress bar */}
-      {loading && <LinearProgress sx={{ mb: 3 }} />}
+      {!sandbox && loading && <LinearProgress sx={{ mb: 3 }} />}
 
       {/* Loading state - show skeletons */}
-      {loading && !initialized && (
+      {!sandbox && loading && !initialized && (
         <Grid container spacing={3}>
           {[1, 2, 3].map((i) => (
             <Grid size={{ xs: 12, sm: 6, md: 4 }} key={i}>
@@ -118,7 +107,7 @@ export default function Courses() {
       )}
 
       {/* Loaded state */}
-      {!loading && initialized && (
+      {(sandbox || (!loading && initialized)) && (
         <>
           {/* Current Courses */}
           <CoursesSection
@@ -143,7 +132,7 @@ export default function Courses() {
           />
 
           {/* Empty state */}
-          {courses.length === 0 && (
+          {visibleCourses.length === 0 && (
             <CoursesEmptyState
               isInstructor={isInstructor}
               onCreateCourse={handleOpenCreateDialog}
@@ -153,11 +142,13 @@ export default function Courses() {
       )}
 
       {/* Create Course Dialog */}
-      <CreateCourseDialog
-        open={createDialogOpen}
-        onClose={() => setCreateDialogOpen(false)}
-        onSubmit={handleCreateCourse}
-      />
+      {allowCreateCourse && (
+        <CreateCourseDialog
+          open={createDialogOpen}
+          onClose={() => setCreateDialogOpen(false)}
+          onSubmit={handleCreateCourse}
+        />
+      )}
     </Box>
   );
 }

--- a/src/pages/Dashboard.jsx
+++ b/src/pages/Dashboard.jsx
@@ -33,10 +33,9 @@ import BookIcon from '@mui/icons-material/Book'
 import LeaderboardIcon from '@mui/icons-material/Leaderboard'
 import { formatDateTime } from '../utils/formatting.js'
 import { API_CONFIG, fetchJson, getActiveUserId } from '../utils/api.js'
-import { useCoursesState } from '../context/CoursesContext.jsx'
-import { useAuthState } from '../context/AuthContext.jsx'
 import { isInstructorRole } from '../utils/auth.js'
 import ThemedCard from '../components/ui/ThemedCard.jsx'
+import { useAppRuntime } from '../hooks/useAppRuntime.js'
 
 const formatPercent = (value) => (value === null || value === undefined ? '—' : `${value.toFixed(1)}%`)
 
@@ -90,38 +89,46 @@ const defaultGradeOverview = {
   lowestScores: [],
 }
 const defaultReleaseOverview = { pastDuePercent: 0, remainingPercent: 0 }
+const isSubmittedGrade = (grade) => grade?.graded_at != null || grade?.graded_by != null
 
 export default function Dashboard() {
   const theme = useTheme()
-  const { user } = useAuthState()
-  const { activeCourseId } = useCoursesState()
+  const {
+    isSandbox: sandbox,
+    sandbox: sandboxData,
+    user: runtimeUser,
+    assignmentPath,
+    assignmentsPath,
+    activeCourseId,
+  } = useAppRuntime()
   const courseId = activeCourseId ?? API_CONFIG.courseId
-  const courseIdForApi = activeCourseId ?? null
-  const userId = getActiveUserId()
+  const courseIdForApi = sandbox ? null : (activeCourseId ?? null)
+  const userId = sandbox ? runtimeUser.id : getActiveUserId()
 
   const analyticsQuery = useQuery({
     queryKey: ['analytics-student', userId, courseIdForApi],
     queryFn: () =>
       fetchJson(`/api/analytics/student-dashboard?userId=${userId}&courseId=${courseIdForApi}`),
-    enabled: !!courseIdForApi && !!userId,
+    enabled: !sandbox && !!courseIdForApi && !!userId,
   })
 
   const gradebookQuery = useQuery({
     queryKey: ['gradebook-summary', courseIdForApi],
     queryFn: () =>
       fetchJson(`/api/analytics/gradebook-summary?courseId=${courseIdForApi}`).catch(() => null),
-    enabled: !!courseIdForApi,
+    enabled: !sandbox && !!courseIdForApi,
   })
 
-  const analyticsData = analyticsQuery.data
-  const gradebookResponse = gradebookQuery.data
-  const isLoadingAnalytics =
-    (analyticsQuery.isPending && !!courseIdForApi) || (gradebookQuery.isPending && !!courseIdForApi)
-  const analyticsError = analyticsQuery.isError
-  const gradebookError = gradebookQuery.isError
+  const analyticsData = sandbox ? sandboxData.dashboardAnalytics : analyticsQuery.data
+  const gradebookResponse = sandbox ? sandboxData.dashboardGradebookSummary : gradebookQuery.data
+  const isLoadingAnalytics = sandbox
+    ? false
+    : ((analyticsQuery.isPending && !!courseIdForApi) || (gradebookQuery.isPending && !!courseIdForApi))
+  const analyticsError = sandbox ? false : analyticsQuery.isError
+  const gradebookError = sandbox ? false : gradebookQuery.isError
 
   const { analytics, gradeTimeline, gradeOverview, releaseOverview } = useMemo(() => {
-    if (!courseIdForApi || !analyticsData) {
+    if ((!sandbox && !courseIdForApi) || !analyticsData) {
       return {
         analytics: emptyAnalytics,
         gradeTimeline: [],
@@ -196,7 +203,7 @@ export default function Dashboard() {
             const score = grade?.final_score ?? grade?.raw_score ?? null
             const percent =
               max > 0 && score != null ? (score / max) * 100 : 0
-            return { percent, title: assignment.title || 'Assignment' }
+            return { id: assignment.id, percent, title: assignment.title || 'Assignment' }
           })
         : (grades || [])
             .filter((g) => g?.Assignment?.is_locked === false)
@@ -205,23 +212,41 @@ export default function Dashboard() {
               const score = grade?.final_score ?? grade?.raw_score
               if (!max || score == null) return list
               list.push({
+                id: grade.assignment_id,
                 percent: (score / max) * 100,
                 title: grade?.Assignment?.title || grade?.title || 'Assignment',
               })
               return list
             }, [])
+    const submittedAssignmentPercents = assignmentPercents.filter((entry) => {
+      const grade = entry.id != null
+        ? gradeMap.get(entry.id) ?? grades.find((item) => item?.assignment_id === entry.id)
+        : null
+      return sandbox ? isSubmittedGrade(grade) : true
+    })
     const totalAssignments =
       unlockedSummary.length > 0
         ? unlockedSummary.length
         : analyticsData?.assignments?.total ?? gradebookSummary?.length ?? grades?.length ?? 0
-    const completedCount = assignmentPercents.filter((a) => a.percent > 0).length
+    const completedCount = sandbox
+      ? submittedAssignmentPercents.length
+      : assignmentPercents.filter((a) => a.percent > 0).length
     let overallPercent = null
-    let scoresForAverage = assignmentPercents.map((a) => a.percent)
-    if (scoresForAverage.length > 0) {
-      if (scoresForAverage.length >= 3) {
-        scoresForAverage = [...scoresForAverage].sort((a, b) => a - b).slice(2)
+    if (sandbox) {
+      const totalPossiblePoints = (grades || []).reduce((sum, grade) => sum + (Number(grade?.max_score) || 0), 0)
+      const totalEarnedPoints = (grades || []).reduce(
+        (sum, grade) => sum + (Number(grade?.final_score ?? grade?.raw_score) || 0),
+        0
+      )
+      overallPercent = totalPossiblePoints > 0 ? (totalEarnedPoints / totalPossiblePoints) * 100 : 0
+    } else {
+      let scoresForAverage = assignmentPercents.map((a) => a.percent)
+      if (scoresForAverage.length > 0) {
+        if (scoresForAverage.length >= 3) {
+          scoresForAverage = [...scoresForAverage].sort((a, b) => a - b).slice(2)
+        }
+        overallPercent = scoresForAverage.reduce((s, p) => s + p, 0) / scoresForAverage.length
       }
-      overallPercent = scoresForAverage.reduce((s, p) => s + p, 0) / scoresForAverage.length
     }
     const classAverage =
       classAvgWithDrop != null
@@ -238,7 +263,7 @@ export default function Dashboard() {
               ? (vals.reduce((sum, v) => sum + v, 0) / vals.length) * 100
               : null
           })()
-    const lowestScores = [...assignmentPercents]
+    const lowestScores = [...(sandbox ? assignmentPercents : assignmentPercents)]
       .sort((a, b) => a.percent - b.percent)
       .slice(0, 2)
     const lowestGrade = lowestScores[0] ?? null
@@ -266,7 +291,7 @@ export default function Dashboard() {
         remainingPercent: Number(remainingPercent.toFixed(1)),
       },
     }
-  }, [courseIdForApi, analyticsData, gradebookResponse])
+  }, [sandbox, courseIdForApi, analyticsData, gradebookResponse])
 
   const [instructorAnalytics, setInstructorAnalytics] = useState({
     gradeSummary: null,
@@ -274,7 +299,7 @@ export default function Dashboard() {
     timeByCategory: [],
   })
   const envDashboardMode = import.meta.env.VITE_DASHBOARD_MODE || 'student'
-  const isInstructor = isInstructorRole(user?.role)
+  const isInstructor = isInstructorRole(runtimeUser?.role)
   const dashboardMode = isInstructor && envDashboardMode === 'instructor'
     ? 'instructor'
     : 'student'
@@ -441,7 +466,7 @@ export default function Dashboard() {
                 </Typography>
                 <Typography variant="body2" color="text.secondary">
                   {gradeOverview.total
-                    ? `${gradeOverview.completed}/${gradeOverview.total} assignments attempted`
+                    ? `${gradeOverview.completed}/${gradeOverview.total} assignments completed`
                     : 'No assignments graded yet'}
                 </Typography>
                 <Typography variant="body2" color="text.secondary">
@@ -499,12 +524,12 @@ export default function Dashboard() {
                     aria-label="Assignments remaining versus due"
                     sx={{
                       width: '100%',
-                      height: { xs: 160, sm: 200 },
-                      minHeight: { xs: 160, sm: 200 },
+                      height: 200,
+                      minHeight: 200,
                       minWidth: 0,
                     }}
                   >
-                    <ResponsiveContainer width="100%" height="100%" minWidth={0} minHeight={0}>
+                    <ResponsiveContainer width="100%" height={200} minWidth={0} minHeight={0}>
                       <PieChart>
                         <Pie
                           data={[
@@ -606,7 +631,7 @@ export default function Dashboard() {
                       size="small"
                       variant="outlined"
                       component={Link}
-                      to={`/student/assignment/${assignment.id}`}
+                      to={assignmentPath(assignment.id)}
                       aria-label={`Open ${assignment.title}`}
                     >
                       Open
@@ -634,7 +659,9 @@ export default function Dashboard() {
                   Unable to load activity metrics.
                 </Typography>
               ) : null}
-              {!analyticsError && analytics.time?.cohort_median_minutes_per_question != null && (
+              {!analyticsError &&
+              analytics.time?.median_minutes_per_question != null &&
+              analytics.time?.cohort_median_minutes_per_question != null && (
                 <Typography variant="body2" color="text.secondary">
                   Your typical time per question is{' '}
                   {analytics.time.median_minutes_per_question != null &&
@@ -876,72 +903,3 @@ export default function Dashboard() {
     </Box>
   )
 }
-
-
-
-/* old dashboard
-
-import { useNavigate } from 'react-router-dom'
-import { Box, Typography, CardContent, Stack, Button } from '@mui/material'
-import ThemedCard from '../components/ui/ThemedCard.jsx'
-
-export default function Dashboard() {
-  const navigate = useNavigate()
-
-  return (
-    <Box sx={{ maxWidth: 900, mx: 'auto' }}>
-      <Typography variant="h4" sx={{ mb: 1, fontWeight: 600 }}>
-        Welcome back
-      </Typography>
-      <Typography variant="body1" color="text.secondary" sx={{ mb: 4 }}>
-        ............................
-      </Typography>
-
-      <Stack spacing={2}>
-        <ThemedCard>
-          <CardContent sx={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', gap: 2 }}>
-            <Box>
-              <Typography variant="h6">Assignments</Typography>
-              <Typography variant="body2" color="text.secondary">
-                View upcoming and submitted assigments
-              </Typography>
-            </Box>
-            <Button variant="contained" onClick={() => navigate('/student/assignments')}>
-              View assignments
-            </Button>
-          </CardContent>
-        </ThemedCard>
-
-        <ThemedCard>
-          <CardContent sx={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', gap: 2 }}>
-            <Box>
-              <Typography variant="h6">Practice</Typography>
-              <Typography variant="body2" color="text.secondary">
-                Sharpen your skills with supplementary problem sets.
-              </Typography>
-            </Box>
-            <Button variant="contained" onClick={() => navigate('/student/practice')}>
-              Start practice
-            </Button>
-          </CardContent>
-        </ThemedCard>
-
-        <ThemedCard>
-          <CardContent sx={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', gap: 2 }}>
-            <Box>
-              <Typography variant="h6">Grades</Typography>
-              <Typography variant="body2" color="text.secondary">
-                Track your progress.
-              </Typography>
-            </Box>
-            <Button variant="contained" onClick={() => navigate('/student/grades')}>
-              View grades
-            </Button>
-          </CardContent>
-        </ThemedCard>
-      </Stack>
-    </Box>
-  )
-}
-
-*/

--- a/src/pages/Grades.jsx
+++ b/src/pages/Grades.jsx
@@ -6,8 +6,8 @@ import ThemedCard from '../components/ui/ThemedCard.jsx'
 import LoadingSpinner from '../components/ui/LoadingSpinner.jsx'
 import { formatDateTime } from '../utils/formatting.js'
 import { API_CONFIG, fetchJson, getActiveUserId } from '../utils/api.js'
-import { useCoursesState } from '../context/CoursesContext.jsx'
 import { sortAssignmentsBySubchapter } from '../utils/assignmentSort.js'
+import { useAppRuntime } from '../hooks/useAppRuntime.js'
 
 function NoRowsOverlay() {
   return (
@@ -20,29 +20,29 @@ function NoRowsOverlay() {
 }
 
 export default function Grades() {
-  const { activeCourseId } = useCoursesState()
+  const { isSandbox, sandbox: sandboxData, user, activeCourseId } = useAppRuntime()
   const courseId = activeCourseId ?? API_CONFIG.courseId
-  const courseIdForApi = activeCourseId ?? null
-  const userId = getActiveUserId()
+  const courseIdForApi = isSandbox ? null : (activeCourseId ?? null)
+  const userId = isSandbox ? user.id : getActiveUserId()
 
   const assignmentsQuery = useQuery({
     queryKey: ['course-assignments', courseIdForApi],
     queryFn: () => fetchJson(`/api/courses/${courseIdForApi}/assignments`),
-    enabled: !!courseIdForApi,
+    enabled: !isSandbox && !!courseIdForApi,
   })
 
   const gradesQuery = useQuery({
     queryKey: ['user-grades', userId],
     queryFn: () => fetchJson(`/api/users/${userId}/grades`),
-    enabled: !!userId,
+    enabled: !isSandbox && !!userId,
   })
 
-  const assignments = assignmentsQuery.data ?? []
-  const grades = gradesQuery.data ?? []
-  const isLoadingGrades = assignmentsQuery.isPending || gradesQuery.isPending
+  const assignments = isSandbox ? sandboxData.assignments : (assignmentsQuery.data ?? [])
+  const grades = isSandbox ? sandboxData.grades : (gradesQuery.data ?? [])
+  const isLoadingGrades = isSandbox ? false : (assignmentsQuery.isPending || gradesQuery.isPending)
 
   const gradeEntries = useMemo(() => {
-    if (!courseIdForApi) return []
+    if (!isSandbox && !courseIdForApi) return []
     const gradedAssignments = sortAssignmentsBySubchapter(
       (assignments || []).filter(
         (a) => a.kind !== 'practice' && a.is_locked === false
@@ -53,27 +53,41 @@ export default function Grades() {
       assignment,
       grade: gradeMap.get(assignment.id) || null,
     }))
-  }, [courseIdForApi, assignments, grades])
+  }, [isSandbox, courseIdForApi, assignments, grades])
 
   const assignmentPercents = useMemo(() => {
-    return gradeEntries.map((entry) => {
+    return gradeEntries.flatMap((entry) => {
       const grade = entry.grade
+      if (isSandbox && (!grade || (grade.graded_at == null && grade.graded_by == null))) {
+        return []
+      }
       const max = grade?.max_score ?? entry.assignment?.total_points ?? 0
       const score = grade?.final_score ?? grade?.raw_score ?? null
       const percent =
         max > 0 && score !== null && score !== undefined ? (score / max) * 100 : 0
-      return percent
+      return [percent]
     })
   }, [gradeEntries])
 
   const overallPercentage = useMemo(() => {
+    if (isSandbox) {
+      const totalPossiblePoints = gradeEntries.reduce(
+        (sum, entry) => sum + (Number(entry.grade?.max_score ?? entry.assignment?.total_points) || 0),
+        0
+      )
+      const totalEarnedPoints = gradeEntries.reduce(
+        (sum, entry) => sum + (Number(entry.grade?.final_score ?? entry.grade?.raw_score) || 0),
+        0
+      )
+      return totalPossiblePoints > 0 ? (totalEarnedPoints / totalPossiblePoints) * 100 : 0
+    }
     if (assignmentPercents.length === 0) return 0
-    let forAverage =
+    const forAverage =
       assignmentPercents.length >= 3
         ? [...assignmentPercents].sort((a, b) => a - b).slice(2)
         : assignmentPercents
     return forAverage.reduce((s, p) => s + p, 0) / forAverage.length
-  }, [assignmentPercents])
+  }, [assignmentPercents, gradeEntries, isSandbox])
 
   const rows = useMemo(
     () =>

--- a/src/pages/Landing.jsx
+++ b/src/pages/Landing.jsx
@@ -1,0 +1,9 @@
+export default function Landing() {
+  return (
+    <ul>
+      <li><a href="/login">log in</a></li>
+      <li><a href="/sandbox/instructor/dashboard">instructor demo</a></li>
+      <li><a href="/sandbox/student/dashboard">student demo</a></li>
+    </ul>
+  )
+}

--- a/src/pages/Practice.jsx
+++ b/src/pages/Practice.jsx
@@ -1,12 +1,12 @@
-import { useEffect, useState } from 'react'
+import { useMemo } from 'react'
 import { useNavigate } from 'react-router-dom'
-import { Box, Typography, CardContent, Chip, Stack, LinearProgress } from '@mui/material'
+import { useQuery } from '@tanstack/react-query'
+import { Box, Typography, CardContent, Chip, Stack } from '@mui/material'
 import ThemedCard from '../components/ui/ThemedCard.jsx'
 import ActivityAccordion from '../components/ui/ActivityAccordion.jsx'
 import { ACTIVITY_TYPES } from '../placeholder/courseActivities.js'
-import { API_CONFIG, fetchJson } from '../utils/api.js'
-import { compareSubchapterLabels, sortAssignmentsBySubchapter } from '../utils/assignmentSort.js'
-import { useCoursesState } from '../context/CoursesContext.jsx'
+import { fetchJson } from '../utils/api.js'
+import { useAppRuntime } from '../hooks/useAppRuntime.js'
 
 const buildCourseStructure = (assignments, sectionTitle) => {
   const chapters = new Map()
@@ -23,33 +23,16 @@ const buildCourseStructure = (assignments, sectionTitle) => {
       dueDate: assignment.due_at ?? assignment.due_date,
       type: ACTIVITY_TYPES.PRACTICE,
       worksheet: { id: assignment.id, proofs: [] },
-      questionCount: Number(assignment.question_count) || 0,
-      answeredCount: Number(assignment.answered_count) || 0,
     })
     chapterEntry.set(subLabel, items)
     chapters.set(chapterLabel, chapterEntry)
   })
 
-  const compareLabels = (a, b) => a.localeCompare(b, undefined, { numeric: true, sensitivity: 'base' })
-  const chapterValue = (label) => {
-    const match = /^Chapter\s+(\d+)/i.exec(label)
-    return match ? Number(match[1]) : null
-  }
-
   return Array.from(chapters.entries())
-    .sort(([labelA], [labelB]) => {
-      const aNum = chapterValue(labelA)
-      const bNum = chapterValue(labelB)
-      if (aNum !== null && bNum !== null) return aNum - bNum
-      if (aNum !== null) return -1
-      if (bNum !== null) return 1
-      return compareLabels(labelA, labelB)
-    })
     .map(([chapterLabel, subMap]) => ({
       id: chapterLabel,
       title: chapterLabel,
       subchapters: Array.from(subMap.entries())
-        .sort(([a], [b]) => compareSubchapterLabels(a, b))
         .map(([subLabel, items]) => ({
           id: `${chapterLabel}-${subLabel}`,
           title: subLabel,
@@ -60,57 +43,38 @@ const buildCourseStructure = (assignments, sectionTitle) => {
 
 export default function Practice() {
   const navigate = useNavigate()
-  const [courseStructure, setCourseStructure] = useState([])
-  const [isLoadingPractice, setIsLoadingPractice] = useState(true)
-  const { activeCourseId } = useCoursesState()
-  const courseId = activeCourseId ?? API_CONFIG.courseId
-  const courseIdForApi = activeCourseId ?? null
+  const {
+    isSandbox,
+    assignmentPath,
+    practicePath,
+    sandbox: sandboxData,
+    activeCourseId,
+  } = useAppRuntime()
+  const courseIdForApi = isSandbox ? null : (activeCourseId ?? null)
 
-  useEffect(() => {
-    let isMounted = true
+  const practiceQuery = useQuery({
+    queryKey: ['course-practice', courseIdForApi],
+    queryFn: async () => {
+      const assignments = await fetchJson(`/api/courses/${courseIdForApi}/assignments`)
+      return assignments.filter((assignment) => assignment.kind === 'practice')
+    },
+    enabled: !isSandbox && !!courseIdForApi,
+  })
 
-    const loadPractice = async () => {
-      try {
-        if (!courseIdForApi) {
-          if (isMounted) {
-            setCourseStructure([])
-            setIsLoadingPractice(false)
-          }
-          return
-        }
-        if (isMounted) {
-          setIsLoadingPractice(true)
-        }
-        const assignments = await fetchJson(`/api/courses/${courseIdForApi}/assignments`)
-        if (!isMounted) return
-
-        const practiceAssignments = sortAssignmentsBySubchapter(
-          assignments.filter((assignment) => assignment.kind === 'practice')
-        )
-        setCourseStructure(buildCourseStructure(practiceAssignments, 'Practice'))
-      } catch (error) {
-        if (isMounted) {
-          console.warn('Failed to load practice assignments', error)
-          setCourseStructure([])
-        }
-      } finally {
-        if (isMounted) {
-          setIsLoadingPractice(false)
-        }
-      }
-    }
-
-    loadPractice()
-
-    return () => {
-      isMounted = false
-    }
-  }, [courseIdForApi])
+  const practiceAssignments = useMemo(
+    () => (isSandbox ? (sandboxData?.practices ?? []) : (practiceQuery.data ?? [])),
+    [isSandbox, practiceQuery.data, sandboxData?.practices]
+  )
+  const courseStructure = useMemo(
+    () => buildCourseStructure(practiceAssignments, 'Practice'),
+    [practiceAssignments]
+  )
+  const isLoadingPractice = isSandbox ? false : practiceQuery.isPending
 
   const handleActivityClick = (activity) => {
     if (activity.worksheet) {
-      navigate(`/student/assignment/${activity.worksheet.id}`, {
-        state: { returnTo: '/student/practice' }
+      navigate(assignmentPath(activity.worksheet.id), {
+        state: { returnTo: practicePath }
       })
     }
   }
@@ -122,30 +86,18 @@ export default function Practice() {
         courseStructure={courseStructure}
         isLoading={isLoadingPractice}
         emptyText="No practice problems available"
-        defaultSubchapterExpanded
         renderActivity={(activity, { chapter, subchapter }) => (
-          (() => {
-            const totalQuestions = Number(activity.questionCount) || 0
-            const completedQuestions = Math.min(Number(activity.answeredCount) || 0, totalQuestions)
-            const completionValue = totalQuestions > 0 ? (completedQuestions / totalQuestions) * 100 : 0
-            return (
           <ThemedCard
             key={activity.id}
             sx={{ cursor: 'pointer', '&:hover': { boxShadow: 4 } }}
             onClick={() => handleActivityClick(activity)}
           >
             <CardContent>
-              <Box
-                sx={{
-                  display: 'grid',
-                  gridTemplateColumns: {
-                    xs: '1fr',
-                    md: 'minmax(0, 1fr) clamp(240px, 28vw, 360px)',
-                  },
-                  columnGap: { xs: 0, md: 4 },
-                  rowGap: 2,
-                  alignItems: 'start',
-                }}
+              <Stack
+                direction={{ xs: 'column', sm: 'row' }}
+                justifyContent="space-between"
+                alignItems={{ xs: 'flex-start', sm: 'flex-start' }}
+                spacing={2}
               >
                 <Box sx={{ flex: 1, minWidth: 0 }}>
                   <Typography variant="h6" sx={{ mb: 1, wordBreak: 'break-word' }}>
@@ -162,58 +114,16 @@ export default function Practice() {
                     </Typography>
                   )}
                 </Box>
-                <Stack spacing={0.75} alignItems={{ xs: 'flex-start', md: 'flex-end' }} width="100%">
-                  <Stack
-                    direction="row"
-                    spacing={1}
-                    alignItems="center"
-                    flexWrap={{ xs: 'wrap', md: 'nowrap' }}
-                    justifyContent={{ xs: 'flex-start', md: 'flex-end' }}
-                    sx={{ width: '100%' }}
-                  >
-                    {totalQuestions > 0 && (
-                      <Stack
-                        direction="row"
-                        spacing={0.75}
-                        alignItems="center"
-                        sx={{
-                          minWidth: { xs: '100%', md: 'auto' },
-                          flex: { xs: '1 1 100%', md: '0 0 auto' },
-                          flexShrink: 0,
-                        }}
-                      >
-                        <Box sx={{ width: { xs: '100%', md: 140 } }}>
-                          <LinearProgress
-                            variant="determinate"
-                            value={completionValue}
-                            aria-label={`Practice completion: ${completedQuestions} of ${totalQuestions} complete`}
-                            sx={{
-                              height: 8,
-                              borderRadius: 999,
-                              bgcolor: 'action.hover',
-                              '& .MuiLinearProgress-bar': { borderRadius: 999 },
-                            }}
-                          />
-                        </Box>
-                        <Typography variant="body2" sx={{ color: 'text.primary', fontWeight: 600, whiteSpace: 'nowrap' }}>
-                          {completedQuestions}/{totalQuestions}
-                        </Typography>
-                      </Stack>
-                    )}
-                    <Chip
-                      label="Practice"
-                      size="small"
-                      color="primary"
-                      variant="outlined"
-                      sx={{ alignSelf: { xs: 'flex-start', md: 'flex-end' } }}
-                    />
-                  </Stack>
-                </Stack>
-              </Box>
+                <Chip
+                  label="Practice"
+                  size="small"
+                  color="primary"
+                  variant="outlined"
+                  sx={{ alignSelf: { xs: 'flex-start', sm: 'center' } }}
+                />
+              </Stack>
             </CardContent>
           </ThemedCard>
-            )
-          })()
         )}
       />
     </Box>

--- a/src/pages/Practice.jsx
+++ b/src/pages/Practice.jsx
@@ -82,13 +82,14 @@ export default function Practice() {
   return (
     <Box>
       <ActivityAccordion
-        title="Practice Problems"
-        courseStructure={courseStructure}
-        isLoading={isLoadingPractice}
-        emptyText="No practice problems available"
-        renderActivity={(activity, { chapter, subchapter }) => (
-          <ThemedCard
-            key={activity.id}
+      title="Practice Problems"
+      courseStructure={courseStructure}
+      isLoading={isLoadingPractice}
+      emptyText="No practice problems available"
+      defaultSubchapterExpanded
+      renderActivity={(activity, { chapter, subchapter }) => (
+        <ThemedCard
+          key={activity.id}
             sx={{ cursor: 'pointer', '&:hover': { boxShadow: 4 } }}
             onClick={() => handleActivityClick(activity)}
           >

--- a/src/pages/Practice.jsx
+++ b/src/pages/Practice.jsx
@@ -6,6 +6,7 @@ import ThemedCard from '../components/ui/ThemedCard.jsx'
 import ActivityAccordion from '../components/ui/ActivityAccordion.jsx'
 import { ACTIVITY_TYPES } from '../placeholder/courseActivities.js'
 import { fetchJson } from '../utils/api.js'
+import { compareSubchapterLabels, sortAssignmentsBySubchapter } from '../utils/assignmentSort.js'
 import { useAppRuntime } from '../hooks/useAppRuntime.js'
 
 const buildCourseStructure = (assignments, sectionTitle) => {
@@ -28,11 +29,26 @@ const buildCourseStructure = (assignments, sectionTitle) => {
     chapters.set(chapterLabel, chapterEntry)
   })
 
+  const compareLabels = (a, b) => a.localeCompare(b, undefined, { numeric: true, sensitivity: 'base' })
+  const chapterValue = (label) => {
+    const match = /^Chapter\s+(\d+)/i.exec(label)
+    return match ? Number(match[1]) : null
+  }
+
   return Array.from(chapters.entries())
+    .sort(([labelA], [labelB]) => {
+      const aNum = chapterValue(labelA)
+      const bNum = chapterValue(labelB)
+      if (aNum !== null && bNum !== null) return aNum - bNum
+      if (aNum !== null) return -1
+      if (bNum !== null) return 1
+      return compareLabels(labelA, labelB)
+    })
     .map(([chapterLabel, subMap]) => ({
       id: chapterLabel,
       title: chapterLabel,
       subchapters: Array.from(subMap.entries())
+        .sort(([a], [b]) => compareSubchapterLabels(a, b))
         .map(([subLabel, items]) => ({
           id: `${chapterLabel}-${subLabel}`,
           title: subLabel,
@@ -62,7 +78,10 @@ export default function Practice() {
   })
 
   const practiceAssignments = useMemo(
-    () => (isSandbox ? (sandboxData?.practices ?? []) : (practiceQuery.data ?? [])),
+    () =>
+      sortAssignmentsBySubchapter(
+        isSandbox ? (sandboxData?.practices ?? []) : (practiceQuery.data ?? [])
+      ),
     [isSandbox, practiceQuery.data, sandboxData?.practices]
   )
   const courseStructure = useMemo(

--- a/src/pages/Worksheet.jsx
+++ b/src/pages/Worksheet.jsx
@@ -13,6 +13,117 @@ import { API_CONFIG, fetchJson, getActiveUserId } from '../utils/api.js'
 import { sortAssignmentsBySubchapter } from '../utils/assignmentSort.js'
 import { displayScoreForProof } from '../utils/problemHelpers.js'
 import { useCoursesState } from '../context/CoursesContext.jsx'
+import { useAppRuntime } from '../hooks/useAppRuntime.js'
+
+function SandboxWorksheetContent() {
+  const { assignmentId } = useParams()
+  const navigate = useNavigate()
+  const location = useLocation()
+  const {
+    assignmentsPath,
+    isInstructor,
+    sandbox,
+    instructorSandbox,
+  } = useAppRuntime()
+  const [currentProofIndex, setCurrentProofIndex] = useState(0)
+
+  const worksheetStore = isInstructor ? instructorSandbox : sandbox
+  const assignment = isInstructor
+    ? worksheetStore?.getActivity?.(assignmentId)
+    : worksheetStore?.getAssignment?.(assignmentId)
+  const getQuestionState = worksheetStore?.getQuestionState ?? (() => null)
+  const isQuestionComplete = worksheetStore?.isQuestionComplete ?? (() => false)
+  const updateQuestionState = worksheetStore?.updateQuestionState ?? (() => undefined)
+  const markQuestionComplete = worksheetStore?.markQuestionComplete ?? (() => undefined)
+
+  const worksheets = useMemo(() => (assignment ? [{ ...assignment, proofs: assignment.proofs || [] }] : []), [assignment])
+  const currentWorksheet = worksheets[0]
+  const total = currentWorksheet?.proofs?.length || 0
+  const backTarget = location?.state?.returnTo || assignmentsPath
+
+  const {
+    completedProofs,
+    score,
+    handleProofComplete,
+    setCompletedProofs,
+  } = useScoring(currentWorksheet)
+
+  useEffect(() => {
+    if (!currentWorksheet?.proofs) return
+    setCompletedProofs(new Set(
+      currentWorksheet.proofs
+        .filter((proof) => isQuestionComplete(proof.id))
+        .map((proof) => proof.id)
+    ))
+  }, [currentWorksheet?.proofs, isQuestionComplete, setCompletedProofs])
+
+  const questionScores = useMemo(() => {
+    const scores = {}
+    for (const proof of currentWorksheet?.proofs || []) {
+      const saved = getQuestionState(proof.id)
+      const rawScore = Number(saved?.rawScore)
+      if (Number.isFinite(rawScore)) {
+        scores[proof.questionId] = rawScore
+      } else if (saved?.lastStatus === 'incorrect') {
+        scores[proof.questionId] = 0
+      } else if (saved?.lastStatus === 'partial') {
+        scores[proof.questionId] = 50
+      } else if (isQuestionComplete(proof.id)) {
+        scores[proof.questionId] = 100
+      }
+    }
+    return scores
+  }, [currentWorksheet?.proofs, getQuestionState, isQuestionComplete])
+
+  const calculatedGradePercent = useMemo(() => {
+    if (!total) return null
+    return (score / total) * 100
+  }, [score, total])
+
+  const { completionPercent, gradeLabel, isOverdue } = useWorksheetMetrics({
+    score,
+    total,
+    calculatedGradePercent,
+    dueAt: currentWorksheet?.dueAt || currentWorksheet?.due_at,
+  })
+
+  if (!currentWorksheet) {
+    return <div>Worksheet not found</div>
+  }
+
+  return (
+    <WorksheetLayout
+      subtitle={currentWorksheet.title || currentWorksheet.name || "Assignment"}
+      onBackToLMS={() => navigate(backTarget)}
+      worksheets={worksheets}
+      currentWorksheetIndex={0}
+      onWorksheetIndexChange={() => {}}
+      completedProofs={completedProofs}
+      isOverdue={isOverdue}
+      isLocked={currentWorksheet.isLocked ?? currentWorksheet.is_locked ?? false}
+      showPolicyInfo
+    >
+      <WorksheetTabs
+        worksheets={worksheets}
+        currentWorksheetIndex={0}
+        onWorksheetIndexChange={() => {}}
+        currentProofIndex={currentProofIndex}
+        onProofIndexChange={setCurrentProofIndex}
+        completedProofs={completedProofs}
+        questionScores={questionScores}
+        onProofComplete={(proofId) => {
+          handleProofComplete(proofId)
+          markQuestionComplete(proofId)
+        }}
+        getSavedProofState={(proofId) => getQuestionState(proofId)}
+        handleProofStateChange={(proofId, state) => updateQuestionState(proofId, state)}
+        total={total}
+        completionPercent={completionPercent}
+        gradeLabel={gradeLabel}
+      />
+    </WorksheetLayout>
+  )
+}
 
 const normalizeType = (snapshot) => (
   snapshot?.type || snapshot?.problemType || snapshot?.logic_problem_type || 'derivation'
@@ -292,7 +403,7 @@ const buildTruthTableState = (lefts, right, data) => {
   return state
 }
 
-export default function Worksheet() {
+function RealWorksheetContent() {
   const { worksheetId, assignmentId } = useParams()
   const navigate = useNavigate()
   const location = useLocation()
@@ -303,6 +414,7 @@ export default function Worksheet() {
   const [currentDueAt, setCurrentDueAt] = useState(null)
   const [questionScores, setQuestionScores] = useState({})
   const { activeCourseId } = useCoursesState()
+  const { assignmentPath, assignmentsPath } = useAppRuntime()
   const courseId = activeCourseId ?? API_CONFIG.courseId
   const courseIdForApi = activeCourseId ?? null
   const sessionId = useRef(null)
@@ -353,9 +465,7 @@ export default function Worksheet() {
   const worksheetDueAt = currentWorksheet?.due_at
     ?? currentWorksheet?.due_date
     ?? currentDueAt
-  const isInstructorView = location.pathname.startsWith('/instructor')
-  const assignmentPathBase = isInstructorView ? '/instructor/assignment' : '/student/assignment'
-  const defaultBackTarget = isInstructorView ? '/instructor/assignments' : '/student/assignments'
+  const defaultBackTarget = assignmentsPath
   const backTarget = location?.state?.returnTo || defaultBackTarget
 
   // total score: sum per-question best (0–100), same as backend
@@ -1045,7 +1155,7 @@ export default function Worksheet() {
   const handleWorksheetChange = (newIndex) => {
     const newWorksheet = worksheets[newIndex]
     if (newWorksheet) {
-      navigate(`${assignmentPathBase}/${newWorksheet.id}`, {
+      navigate(assignmentPath(newWorksheet.id), {
         state: { returnTo: backTarget }
       })
     }
@@ -1154,4 +1264,9 @@ export default function Worksheet() {
       </WorksheetLayout>
     </Box>
   )
+}
+
+export default function Worksheet() {
+  const runtime = useAppRuntime()
+  return runtime.isSandbox ? <SandboxWorksheetContent /> : <RealWorksheetContent />
 }

--- a/src/pages/Worksheet.jsx
+++ b/src/pages/Worksheet.jsx
@@ -414,7 +414,7 @@ function RealWorksheetContent() {
   const [currentDueAt, setCurrentDueAt] = useState(null)
   const [questionScores, setQuestionScores] = useState({})
   const { activeCourseId } = useCoursesState()
-  const { assignmentPath, assignmentsPath } = useAppRuntime()
+  const { assignmentPath, assignmentsPath, isInstructor } = useAppRuntime()
   const courseId = activeCourseId ?? API_CONFIG.courseId
   const courseIdForApi = activeCourseId ?? null
   const sessionId = useRef(null)
@@ -1257,7 +1257,7 @@ function RealWorksheetContent() {
           gradeLabel={gradeLabel}
           policySummary={policySummary}
           isOverdue={isOverdue}
-          isInstructorView={isInstructorView}
+          isInstructorView={isInstructor}
           onQuestionSaved={currentWorksheet?.id ? (qId) => refreshQuestionSolutions(currentWorksheet.id, qId) : undefined}
           onQuestionCreated={handleQuestionCreated}
         />

--- a/src/pages/instructor/InstructorAssignments.jsx
+++ b/src/pages/instructor/InstructorAssignments.jsx
@@ -50,8 +50,7 @@ export default function InstructorAssignments() {
   const {
     courseState,
     courseActions,
-    assignmentPath,
-    assignmentsPath,
+    assignmentBuilderPath,
   } = useAppRuntime();
   const { activeCourseId, assignmentsByCourse, gradebookByCourse, courses } = courseState;
   const navigate = useNavigate();
@@ -110,8 +109,8 @@ export default function InstructorAssignments() {
     try {
       const created = await courseActions.createAssignment?.(activeCourseId, formData);
       setCreateDialogOpen(false);
-      navigate(assignmentPath(created?.id), {
-        state: { returnTo: assignmentsPath, assignmentId: created?.id },
+      navigate(assignmentBuilderPath, {
+        state: { assignmentId: created?.id },
       });
     } catch (error) {
       console.error("Failed to create assignment", error);
@@ -189,11 +188,11 @@ export default function InstructorAssignments() {
   };
 
   const handleViewAssignment = (assignment) => {
-    navigate(assignmentPath(assignment.id), { state: { returnTo: assignmentsPath, assignmentId: assignment.id } });
+    navigate(assignmentBuilderPath, { state: { assignmentId: assignment.id } });
   };
 
   const handleOpenBuilder = (assignment) => {
-    navigate(assignmentPath(assignment.id), { state: { returnTo: assignmentsPath, assignmentId: assignment.id } });
+    navigate(assignmentBuilderPath, { state: { assignmentId: assignment.id } });
     setMenuAnchor(null);
   };
 

--- a/src/pages/instructor/InstructorAssignments.jsx
+++ b/src/pages/instructor/InstructorAssignments.jsx
@@ -13,12 +13,8 @@ import {
 import { Plus } from "lucide-react";
 import { useNavigate } from "react-router-dom";
 import {
-  useCoursesState,
-  useCoursesDispatch,
   calculateAssignmentAverage,
-  fetchCourseAssignments,
 } from "../../context/CoursesContext";
-import { fetchJson } from "../../utils/api.js";
 import AssignmentTable from "../../components/ui/AssignmentTable";
 import AssignmentFormDialog from "../../components/ui/AssignmentFormDialog";
 import AssignmentContextMenu from "../../components/ui/AssignmentContextMenu";
@@ -28,6 +24,7 @@ import {
   getStatusText,
   enhanceItems,
 } from "../../utils/assignmentStatus";
+import { useAppRuntime } from "../../hooks/useAppRuntime.js";
 
 // Helper to get current date
 const getCurrentDate = () => {
@@ -36,27 +33,6 @@ const getCurrentDate = () => {
   const month = String(today.getMonth() + 1).padStart(2, "0");
   const day = String(today.getDate()).padStart(2, "0");
   return `${year}-${month}-${day}`;
-};
-
-const toIsoDateTime = (date, time) => {
-  if (!date) return null;
-  const safeTime = time || "00:00";
-  return new Date(`${date}T${safeTime}:00`).toISOString();
-};
-
-const buildAssignmentPayload = (formData, courseId, overrides = {}) => {
-  const dueDate = toIsoDateTime(formData.dueDate, formData.dueTime || "23:59");
-  return {
-    course_id: courseId,
-    kind: "assignment",
-    title: formData.name,
-    description: formData.description || null,
-    is_locked: formData.isLocked,
-    chapter: Number(formData.chapter) || 1,
-    subchapter: formData.subchapter || "",
-    due_date: dueDate,
-    ...overrides,
-  };
 };
 
 const INITIAL_FORM_DATA = {
@@ -71,9 +47,13 @@ const INITIAL_FORM_DATA = {
 };
 
 export default function InstructorAssignments() {
-  const { activeCourseId, assignmentsByCourse, gradebookByCourse, courses } =
-    useCoursesState();
-  const dispatch = useCoursesDispatch();
+  const {
+    courseState,
+    courseActions,
+    assignmentPath,
+    assignmentsPath,
+  } = useAppRuntime();
+  const { activeCourseId, assignmentsByCourse, gradebookByCourse, courses } = courseState;
   const navigate = useNavigate();
 
   const [createDialogOpen, setCreateDialogOpen] = useState(false);
@@ -128,21 +108,10 @@ export default function InstructorAssignments() {
     if (isCreating) return;
     setIsCreating(true);
     try {
-      const payload = buildAssignmentPayload(formData, activeCourseId);
-      const created = await fetchJson("/api/assignments", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify(payload),
-      });
-      const refreshed = await fetchCourseAssignments(activeCourseId);
-      dispatch({
-        type: "SET_ASSIGNMENTS",
-        courseId: activeCourseId,
-        payload: refreshed,
-      });
+      const created = await courseActions.createAssignment?.(activeCourseId, formData);
       setCreateDialogOpen(false);
-      navigate("/instructor/assignment-builder", {
-        state: { assignmentId: created?.id ?? payload.id },
+      navigate(assignmentPath(created?.id), {
+        state: { returnTo: assignmentsPath, assignmentId: created?.id },
       });
     } catch (error) {
       console.error("Failed to create assignment", error);
@@ -171,18 +140,7 @@ export default function InstructorAssignments() {
 
   const handleEditSubmit = async () => {
     try {
-      const payload = buildAssignmentPayload(formData, activeCourseId);
-      await fetchJson(`/api/assignments/${selectedAssignment.id}`, {
-        method: "PUT",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify(payload),
-      });
-      const refreshed = await fetchCourseAssignments(activeCourseId);
-      dispatch({
-        type: "SET_ASSIGNMENTS",
-        courseId: activeCourseId,
-        payload: refreshed,
-      });
+      await courseActions.updateAssignment?.(activeCourseId, selectedAssignment.id, formData);
       setEditDialogOpen(false);
       setSelectedAssignment(null);
     } catch (error) {
@@ -194,17 +152,7 @@ export default function InstructorAssignments() {
     const assignment = assignments.find((a) => a.id === assignmentId);
     if (!assignment) return;
     try {
-      await fetchJson(`/api/assignments/${assignmentId}`, {
-        method: "PUT",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ is_locked: !assignment.isLocked }),
-      });
-      const refreshed = await fetchCourseAssignments(activeCourseId);
-      dispatch({
-        type: "SET_ASSIGNMENTS",
-        courseId: activeCourseId,
-        payload: refreshed,
-      });
+      await courseActions.toggleAssignmentLock?.(activeCourseId, assignmentId, assignment);
     } catch (error) {
       console.error("Failed to toggle lock", error);
     }
@@ -213,19 +161,8 @@ export default function InstructorAssignments() {
   const handleTogglePublish = async (assignmentId) => {
     const assignment = assignments.find((a) => a.id === assignmentId);
     if (!assignment) return;
-    const nextPublished = !assignment.isPublished;
     try {
-      await fetchJson(`/api/assignments/${assignmentId}`, {
-        method: "PUT",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ is_locked: assignment.isLocked || !nextPublished }),
-      });
-      const refreshed = await fetchCourseAssignments(activeCourseId);
-      dispatch({
-        type: "SET_ASSIGNMENTS",
-        courseId: activeCourseId,
-        payload: refreshed,
-      });
+      await courseActions.toggleAssignmentPublish?.(activeCourseId, assignmentId, assignment);
     } catch (error) {
       console.error("Failed to toggle publish", error);
     }
@@ -233,31 +170,7 @@ export default function InstructorAssignments() {
 
   const handleDuplicate = async (assignment) => {
     try {
-      const payload = {
-        course_id: activeCourseId,
-        kind: "assignment",
-        title: `${assignment.name} (Copy)`,
-        description: assignment.description || null,
-        is_locked: true,
-        chapter: assignment.chapter || 1,
-        subchapter: assignment.subchapter || "",
-        due_date: assignment.dueDate
-          ? toIsoDateTime(assignment.dueDate, assignment.dueTime || "23:59")
-          : null,
-        late_window_days: assignment.lateWindowDays,
-        late_penalty_percent: assignment.latePenaltyPercent,
-      };
-      await fetchJson("/api/assignments", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify(payload),
-      });
-      const refreshed = await fetchCourseAssignments(activeCourseId);
-      dispatch({
-        type: "SET_ASSIGNMENTS",
-        courseId: activeCourseId,
-        payload: refreshed,
-      });
+      await courseActions.duplicateAssignment?.(activeCourseId, assignment);
       setMenuAnchor(null);
     } catch (error) {
       console.error("Failed to duplicate assignment", error);
@@ -267,15 +180,7 @@ export default function InstructorAssignments() {
   const handleDelete = async (assignmentId) => {
     if (window.confirm("Are you sure you want to delete this assignment?")) {
       try {
-        await fetchJson(`/api/assignments/${assignmentId}`, {
-          method: "DELETE",
-        });
-        const refreshed = await fetchCourseAssignments(activeCourseId);
-        dispatch({
-          type: "SET_ASSIGNMENTS",
-          courseId: activeCourseId,
-          payload: refreshed,
-        });
+        await courseActions.deleteAssignment?.(activeCourseId, assignmentId);
       } catch (error) {
         console.error("Failed to delete assignment", error);
       }
@@ -284,15 +189,11 @@ export default function InstructorAssignments() {
   };
 
   const handleViewAssignment = (assignment) => {
-    navigate("/instructor/assignment-builder", {
-      state: { assignmentId: assignment.id },
-    });
+    navigate(assignmentPath(assignment.id), { state: { returnTo: assignmentsPath, assignmentId: assignment.id } });
   };
 
   const handleOpenBuilder = (assignment) => {
-    navigate("/instructor/assignment-builder", {
-      state: { assignmentId: assignment.id },
-    });
+    navigate(assignmentPath(assignment.id), { state: { returnTo: assignmentsPath, assignmentId: assignment.id } });
     setMenuAnchor(null);
   };
 
@@ -309,18 +210,12 @@ export default function InstructorAssignments() {
   const handleEditDueDateSubmit = async () => {
     if (!dueDateEditAssignment?.id || !dueDateForm.dueDate) return;
     try {
-      const dueDate = toIsoDateTime(dueDateForm.dueDate, dueDateForm.dueTime || "23:59");
-      await fetchJson(`/api/assignments/${dueDateEditAssignment.id}`, {
-        method: "PUT",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ due_date: dueDate }),
-      });
-      const refreshed = await fetchCourseAssignments(activeCourseId);
-      dispatch({
-        type: "SET_ASSIGNMENTS",
-        courseId: activeCourseId,
-        payload: refreshed,
-      });
+      await courseActions.updateAssignmentDueDate?.(
+        activeCourseId,
+        dueDateEditAssignment.id,
+        dueDateForm.dueDate,
+        dueDateForm.dueTime || "23:59"
+      );
       setDueDateDialogOpen(false);
       setDueDateEditAssignment(null);
     } catch (error) {

--- a/src/pages/instructor/InstructorControls.jsx
+++ b/src/pages/instructor/InstructorControls.jsx
@@ -1,20 +1,15 @@
 import { useState } from "react";
 import { Box, Typography, Button, Alert } from "@mui/material";
 import { Save } from "lucide-react";
-import {
-  useCoursesState,
-  useCoursesDispatch,
-  saveCourseSettings,
-  toggleArchiveCourse,
-} from "../../context/CoursesContext";
 import CourseInfoSection from "../../components/ui/instructorControls/CourseInfoSection";
 import GradingScaleSection from "../../components/ui/instructorControls/GradingScaleSection";
 import LatePolicySection from "../../components/ui/instructorControls/LatePolicySection";
 import CourseStatusSection from "../../components/ui/instructorControls/CourseStatusSection";
+import { useAppRuntime } from "../../hooks/useAppRuntime.js";
 
 export default function InstructorControls() {
-  const { courses, activeCourseId } = useCoursesState();
-  const dispatch = useCoursesDispatch();
+  const { courseState, courseActions } = useAppRuntime();
+  const { courses, activeCourseId } = courseState;
 
   const activeCourse = courses.find((c) => c.id === activeCourseId);
 
@@ -22,14 +17,14 @@ export default function InstructorControls() {
   const [errors, setErrors] = useState([]);
 
   const handleSave = async (settings) => {
-    await saveCourseSettings(dispatch, activeCourseId, settings);
+    await courseActions.saveCourseSettings?.(activeCourseId, settings);
 
     setShowSuccess(true);
     setTimeout(() => setShowSuccess(false), 3000);
   };
 
   const handleArchiveCourse = async (courseId, archive = true) => {
-    await toggleArchiveCourse(dispatch, courseId, archive);
+    await courseActions.toggleArchiveCourse?.(courseId, archive);
 
     setShowSuccess(true);
     setTimeout(() => setShowSuccess(false), 3000);

--- a/src/pages/instructor/InstructorDashboard.jsx
+++ b/src/pages/instructor/InstructorDashboard.jsx
@@ -2,11 +2,9 @@ import { Box, Typography, Alert, LinearProgress, useTheme } from "@mui/material"
 import { useEffect, useMemo, useState } from "react";
 import { TrendingUp, Users, CheckCircle, Calendar } from "lucide-react";
 import {
-  useCoursesState,
   calculateAssignmentAverage,
   calculateGradeDistribution,
 } from "../../context/CoursesContext";
-import { fetchJson } from "../../utils/api.js";
 import { MetricCard } from "../../components/ui/MetricCard";
 import { PerformanceTrendsChart } from "../../components/ui/dashboard/PerformanceTrendsChart";
 import { GradeDistributionChart } from "../../components/ui/dashboard/GradeDistributionChart";
@@ -15,11 +13,12 @@ import { UpcomingDeadlinesTable } from "../../components/ui/dashboard/UpcomingDe
 import { AssignmentOverviewTable } from "../../components/ui/dashboard/AssignmentOverviewTable";
 import { sortAssignmentsBySubchapter } from "../../utils/assignmentSort.js";
 import { formatEasternDateTime } from "../../utils/easternTime.js";
+import { useAppRuntime } from "../../hooks/useAppRuntime.js";
 
 export default function InstructorDashboard() {
   const theme = useTheme();
-  const { courses, activeCourseId, assignmentsByCourse, gradebookByCourse } =
-    useCoursesState();
+  const { courseState, courseActions } = useAppRuntime();
+  const { courses, activeCourseId, assignmentsByCourse, gradebookByCourse } = courseState;
   const [isLoadingAnalytics, setIsLoadingAnalytics] = useState(true);
   const [analytics, setAnalytics] = useState({
     gradeSummary: null,
@@ -45,13 +44,10 @@ export default function InstructorDashboard() {
         return;
       }
       try {
-        const [instructorAnalytics, summary] = await Promise.all([
-          fetchJson(`/api/analytics/instructor-dashboard?courseId=${activeCourseId}`),
-          fetchJson(`/api/analytics/gradebook-summary?courseId=${activeCourseId}`),
-        ]);
+        const snapshot = await courseActions.loadInstructorDashboard?.(activeCourseId);
         if (isMounted) {
-          setAnalytics(instructorAnalytics);
-          setGradebookSummary(Array.isArray(summary) ? summary : (summary?.assignments ?? []));
+          setAnalytics(snapshot?.analytics || { gradeSummary: null, assignmentStats: [], timeByCategory: [] });
+          setGradebookSummary(snapshot?.gradebookSummary || []);
         }
       } catch (error) {
         if (isMounted) {
@@ -68,7 +64,7 @@ export default function InstructorDashboard() {
     return () => {
       isMounted = false;
     };
-  }, [activeCourseId]);
+  }, [activeCourseId, courseActions]);
 
   const nonPracticeAssignments = useMemo(
     () => assignments.filter((assignment) => assignment.kind !== "practice"),

--- a/src/pages/instructor/InstructorGradebook.jsx
+++ b/src/pages/instructor/InstructorGradebook.jsx
@@ -1,17 +1,17 @@
 import { useState } from "react";
 import { Box, Typography, Button } from "@mui/material";
 import { Download } from "lucide-react";
-import { useCoursesState } from "../../context/CoursesContext";
 import GradebookTable from "../../components/ui/gradebook/GradebookTable";
 import {
   sortStudents,
   exportGradebookCSV,
 } from "../../utils/GradebookUtils";
 import { sortAssignmentsBySubchapter } from "../../utils/assignmentSort.js";
+import { useAppRuntime } from "../../hooks/useAppRuntime.js";
 
 export default function InstructorGradebook() {
-  const { courses, activeCourseId, assignmentsByCourse, gradebookByCourse } =
-    useCoursesState();
+  const { courseState } = useAppRuntime();
+  const { courses, activeCourseId, assignmentsByCourse, gradebookByCourse } = courseState;
 
   // Sort states
   const [sortColumn, setSortColumn] = useState("username");

--- a/src/pages/instructor/InstructorPractice.jsx
+++ b/src/pages/instructor/InstructorPractice.jsx
@@ -2,12 +2,6 @@ import { useState } from "react";
 import { Box, Typography, Button, Alert } from "@mui/material";
 import { Plus, Brain } from "lucide-react";
 import { useNavigate } from "react-router-dom";
-import {
-  useCoursesState,
-  useCoursesDispatch,
-  fetchCoursePractices,
-} from "../../context/CoursesContext";
-import { fetchJson } from "../../utils/api.js";
 import AssignmentTable from "../../components/ui/AssignmentTable";
 import AssignmentFormDialog from "../../components/ui/AssignmentFormDialog";
 import AssignmentContextMenu from "../../components/ui/AssignmentContextMenu";
@@ -17,6 +11,7 @@ import {
   getStatusText,
   enhanceItems,
 } from "../../utils/assignmentStatus";
+import { useAppRuntime } from "../../hooks/useAppRuntime.js";
 
 const getCurrentEasternDate = () => new Date().toLocaleDateString('en-CA', { timeZone: 'America/New_York' });
 
@@ -34,8 +29,13 @@ const INITIAL_FORM_DATA = {
 };
 
 export default function InstructorPractice() {
-  const { activeCourseId, practicesByCourse, courses } = useCoursesState();
-  const dispatch = useCoursesDispatch();
+  const {
+    courseState,
+    courseActions,
+    assignmentPath,
+    practicePath,
+  } = useAppRuntime();
+  const { activeCourseId, practicesByCourse, courses } = courseState;
   const navigate = useNavigate();
 
   const [createDialogOpen, setCreateDialogOpen] = useState(false);
@@ -53,8 +53,8 @@ export default function InstructorPractice() {
 
   const navigateToPractice = (practiceId) => {
     if (!practiceId) return;
-    navigate(`/instructor/assignment/${practiceId}`, {
-      state: { returnTo: "/instructor/practice" },
+    navigate(assignmentPath(practiceId), {
+      state: { returnTo: practicePath },
     });
   };
 
@@ -74,31 +74,9 @@ export default function InstructorPractice() {
     if (isCreating) return;
     setIsCreating(true);
     try {
-      const payload = {
-        course_id: activeCourseId,
-        kind: "practice",
-        title: formData.name,
-        description: formData.description || null,
-        is_locked: formData.isLocked,
-        chapter: Number(formData.chapter) || 1,
-        subchapter: formData.subchapter || "A",
-        due_date: null,
-        late_window_days: null,
-        late_penalty_percent: null,
-      };
-      const created = await fetchJson("/api/assignments", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify(payload),
-      });
-      const refreshed = await fetchCoursePractices(activeCourseId);
-      dispatch({
-        type: "SET_PRACTICES",
-        courseId: activeCourseId,
-        payload: refreshed,
-      });
+      const created = await courseActions.createPractice?.(activeCourseId, formData);
       setCreateDialogOpen(false);
-      navigateToPractice(created?.id ?? payload.id);
+      navigateToPractice(created?.id);
     } catch (error) {
       console.error("Failed to create practice", error);
     } finally {
@@ -126,29 +104,7 @@ export default function InstructorPractice() {
 
   const handleEditSubmit = async () => {
     try {
-      const payload = {
-        course_id: activeCourseId,
-        kind: "practice",
-        title: formData.name,
-        description: formData.description || null,
-        is_locked: formData.isLocked,
-        chapter: Number(formData.chapter) || 1,
-        subchapter: formData.subchapter || "A",
-        due_date: null,
-        late_window_days: null,
-        late_penalty_percent: null,
-      };
-      await fetchJson(`/api/assignments/${selectedPractice.id}`, {
-        method: "PUT",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify(payload),
-      });
-      const refreshed = await fetchCoursePractices(activeCourseId);
-      dispatch({
-        type: "SET_PRACTICES",
-        courseId: activeCourseId,
-        payload: refreshed,
-      });
+      await courseActions.updatePractice?.(activeCourseId, selectedPractice.id, formData);
       setEditDialogOpen(false);
       setSelectedPractice(null);
     } catch (error) {
@@ -160,17 +116,7 @@ export default function InstructorPractice() {
     const practice = practices.find((p) => p.id === practiceId);
     if (!practice) return;
     try {
-      await fetchJson(`/api/assignments/${practiceId}`, {
-        method: "PUT",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ is_locked: !practice.isLocked }),
-      });
-      const refreshed = await fetchCoursePractices(activeCourseId);
-      dispatch({
-        type: "SET_PRACTICES",
-        courseId: activeCourseId,
-        payload: refreshed,
-      });
+      await courseActions.togglePracticeLock?.(activeCourseId, practiceId, practice);
     } catch (error) {
       console.error("Failed to toggle lock", error);
     }
@@ -179,19 +125,8 @@ export default function InstructorPractice() {
   const handleTogglePublish = async (practiceId) => {
     const practice = practices.find((p) => p.id === practiceId);
     if (!practice) return;
-    const nextPublished = !practice.isPublished;
     try {
-      await fetchJson(`/api/assignments/${practiceId}`, {
-        method: "PUT",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ is_locked: practice.isLocked || !nextPublished }),
-      });
-      const refreshed = await fetchCoursePractices(activeCourseId);
-      dispatch({
-        type: "SET_PRACTICES",
-        courseId: activeCourseId,
-        payload: refreshed,
-      });
+      await courseActions.togglePracticePublish?.(activeCourseId, practiceId, practice);
     } catch (error) {
       console.error("Failed to toggle publish", error);
     }
@@ -199,29 +134,7 @@ export default function InstructorPractice() {
 
   const handleDuplicate = async (practice) => {
     try {
-      const payload = {
-        course_id: activeCourseId,
-        kind: "practice",
-        title: `${practice.name} (Copy)`,
-        description: practice.description || null,
-        is_locked: true,
-        chapter: practice.chapter || 1,
-        subchapter: practice.subchapter || "A",
-        due_date: null,
-        late_window_days: null,
-        late_penalty_percent: null,
-      };
-      await fetchJson("/api/assignments", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify(payload),
-      });
-      const refreshed = await fetchCoursePractices(activeCourseId);
-      dispatch({
-        type: "SET_PRACTICES",
-        courseId: activeCourseId,
-        payload: refreshed,
-      });
+      await courseActions.duplicatePractice?.(activeCourseId, practice);
       setMenuAnchor(null);
     } catch (error) {
       console.error("Failed to duplicate practice", error);
@@ -235,15 +148,7 @@ export default function InstructorPractice() {
       )
     ) {
       try {
-        await fetchJson(`/api/assignments/${practiceId}`, {
-          method: "DELETE",
-        });
-        const refreshed = await fetchCoursePractices(activeCourseId);
-        dispatch({
-          type: "SET_PRACTICES",
-          courseId: activeCourseId,
-          payload: refreshed,
-        });
+        await courseActions.deletePractice?.(activeCourseId, practiceId);
       } catch (error) {
         console.error("Failed to delete practice", error);
       }
@@ -331,6 +236,7 @@ export default function InstructorPractice() {
         open={Boolean(menuAnchor)}
         onClose={() => setMenuAnchor(null)}
         item={menuPractice}
+        onOpenBuilder={handleViewPractice}
         onEdit={handleEditOpen}
         onDuplicate={handleDuplicate}
         onDelete={handleDelete}

--- a/src/pages/instructor/InstructorRoster.jsx
+++ b/src/pages/instructor/InstructorRoster.jsx
@@ -1,12 +1,5 @@
 import { useState } from "react";
 import { Box, Alert } from "@mui/material";
-import {
-  useCoursesState,
-  useCoursesDispatch,
-  addStudentToCourse,
-  removeStudentFromCourse,
-  bulkCreateStudents,
-} from "../../context/CoursesContext";
 import AddStudentDialog from "../../components/ui/AddStudentDialog";
 import StudentProfileModal from "../../components/ui/StudentProfileModal";
 import ImportRosterDialog from "../../components/ui/roster/ImportRosterDialog";
@@ -21,12 +14,11 @@ import {
   calculateClassStats,
   exportRosterCSV,
 } from "../../utils/rosterUtils";
-import { updateEnrollmentRole } from "../../context/CoursesContext";
+import { useAppRuntime } from "../../hooks/useAppRuntime.js";
 
 export default function InstructorRoster() {
-  const { activeCourseId, gradebookByCourse, assignmentsByCourse, courses } =
-    useCoursesState();
-  const dispatch = useCoursesDispatch();
+  const { courseState, courseActions } = useAppRuntime();
+  const { activeCourseId, gradebookByCourse, assignmentsByCourse, courses } = courseState;
 
   const [searchQuery, setSearchQuery] = useState("");
   const [addDialogOpen, setAddDialogOpen] = useState(false);
@@ -50,7 +42,7 @@ export default function InstructorRoster() {
 
   // Handlers
   const handleAddStudent = (studentData) =>
-    addStudentToCourse(dispatch, activeCourseId, studentData);
+    courseActions.addStudentToCourse?.(activeCourseId, studentData);
 
   const handleStudentClick = (student) => {
     setSelectedStudent(student);
@@ -63,7 +55,7 @@ export default function InstructorRoster() {
         "Are you sure you want to remove this student from the course? This will delete all their grades."
       )
     ) {
-      await removeStudentFromCourse(dispatch, activeCourseId, studentId);
+      await courseActions.removeStudentFromCourse?.(activeCourseId, studentId);
     }
     setMenuAnchor(null);
   };
@@ -74,30 +66,7 @@ export default function InstructorRoster() {
 
   const handleImportRoster = async (studentsToImport) => {
     try {
-      const response = await bulkCreateStudents(activeCourseId, studentsToImport);
-      const imported = response?.students || [];
-      const newStudents = imported.map((student) => ({
-        id: student.id,
-        username: student.username,
-        grades: {},
-        lateSubmissions: {},
-        submissionDates: {},
-        practices: {},
-      }));
-
-      const updatedGradebook = [...students, ...newStudents];
-
-      dispatch({
-        type: "SET_GRADEBOOK",
-        courseId: activeCourseId,
-        payload: updatedGradebook,
-      });
-
-      dispatch({
-        type: "UPDATE_COURSE_SETTINGS",
-        courseId: activeCourseId,
-        payload: { studentCount: updatedGradebook.length },
-      });
+      await courseActions.bulkAddStudents?.(activeCourseId, studentsToImport, students);
     } catch (error) {
       console.error("Failed to import roster:", error);
     } finally {
@@ -113,11 +82,7 @@ export default function InstructorRoster() {
 
   const handleToggleRole = async (student, newRole) => {
     try {
-      await updateEnrollmentRole(activeCourseId, student.id, newRole);
-      const updated = (gradebookByCourse[activeCourseId] || []).map((s) =>
-        s.id === student.id ? { ...s, role: newRole } : s
-      );
-      dispatch({ type: "SET_GRADEBOOK", courseId: activeCourseId, payload: updated });
+      await courseActions.updateStudentRole?.(activeCourseId, student.id, newRole, gradebookByCourse[activeCourseId] || []);
       setSelectedStudent((prev) =>
         prev?.id === student.id ? { ...prev, role: newRole } : prev
       );

--- a/src/runtime/appRuntime.js
+++ b/src/runtime/appRuntime.js
@@ -1,0 +1,289 @@
+import {
+  addNewCourse,
+  addStudentToCourse,
+  bulkCreateStudents,
+  fetchCourseAssignments,
+  fetchCoursePractices,
+  initializeCourses,
+  removeStudentFromCourse,
+  resetCourses,
+  saveCourseSettings,
+  setActiveCourse,
+  toggleArchiveCourse,
+  updateEnrollmentRole,
+} from "../context/CoursesContext.jsx";
+import { fetchJson } from "../utils/api.js";
+import { buildBreadcrumbInfo, buildRuntimePaths, remapStudentPath } from "./sandboxRuntime.js";
+
+const toIsoDateTime = (date, time) => {
+  if (!date) return null;
+  const safeTime = time || "00:00";
+  return new Date(`${date}T${safeTime}:00`).toISOString();
+};
+
+const buildAssignmentPayload = (formData, courseId, overrides = {}) => {
+  const dueDate = toIsoDateTime(formData.dueDate, formData.dueTime || "23:59");
+  return {
+    course_id: courseId,
+    kind: "assignment",
+    title: formData.name,
+    description: formData.description || null,
+    is_locked: formData.isLocked,
+    chapter: Number(formData.chapter) || 1,
+    subchapter: formData.subchapter || "",
+    due_date: dueDate,
+    ...overrides,
+  };
+};
+
+const buildPracticePayload = (formData, courseId, overrides = {}) => ({
+  course_id: courseId,
+  kind: "practice",
+  title: formData.name,
+  description: formData.description || null,
+  is_locked: formData.isLocked,
+  chapter: Number(formData.chapter) || 1,
+  subchapter: formData.subchapter || "A",
+  due_date: null,
+  late_window_days: null,
+  late_penalty_percent: null,
+  ...overrides,
+});
+
+export function createAppRuntime({ coursesDispatch, coursesState, routeKind, user }) {
+  const runtimePaths = buildRuntimePaths(routeKind);
+  const runtimeCourseActions = {
+    initializeCourses: async () => initializeCourses(coursesDispatch),
+    setActiveCourse: (courseId) => setActiveCourse(coursesDispatch, courseId),
+    resetCourses: () => resetCourses(coursesDispatch),
+    addNewCourse: async (courseData) => addNewCourse(coursesDispatch, courseData),
+    setAssignments: (courseId, payload) => coursesDispatch({ type: "SET_ASSIGNMENTS", courseId, payload }),
+    setPractices: (courseId, payload) => coursesDispatch({ type: "SET_PRACTICES", courseId, payload }),
+    setGradebook: (courseId, payload) => coursesDispatch({ type: "SET_GRADEBOOK", courseId, payload }),
+    updateCourseSettings: (courseId, payload) =>
+      coursesDispatch({ type: "UPDATE_COURSE_SETTINGS", courseId, payload }),
+    saveCourseSettings: async (courseId, settings) => saveCourseSettings(coursesDispatch, courseId, settings),
+    toggleArchiveCourse: async (courseId, archive = true) => toggleArchiveCourse(coursesDispatch, courseId, archive),
+    addStudentToCourse: async (courseId, studentData) => addStudentToCourse(coursesDispatch, courseId, studentData),
+    removeStudentFromCourse: async (courseId, studentId) => removeStudentFromCourse(coursesDispatch, courseId, studentId),
+    createAssignment: async (courseId, formData) => {
+      const created = await fetchJson("/api/assignments", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(buildAssignmentPayload(formData, courseId)),
+      });
+      const refreshed = await fetchCourseAssignments(courseId);
+      coursesDispatch({ type: "SET_ASSIGNMENTS", courseId, payload: refreshed });
+      return created;
+    },
+    updateAssignment: async (courseId, assignmentId, formData) => {
+      await fetchJson(`/api/assignments/${assignmentId}`, {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(buildAssignmentPayload(formData, courseId)),
+      });
+      const refreshed = await fetchCourseAssignments(courseId);
+      coursesDispatch({ type: "SET_ASSIGNMENTS", courseId, payload: refreshed });
+    },
+    toggleAssignmentLock: async (courseId, assignmentId, assignment) => {
+      await fetchJson(`/api/assignments/${assignmentId}`, {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ is_locked: !assignment.isLocked }),
+      });
+      const refreshed = await fetchCourseAssignments(courseId);
+      coursesDispatch({ type: "SET_ASSIGNMENTS", courseId, payload: refreshed });
+    },
+    toggleAssignmentPublish: async (courseId, assignmentId, assignment) => {
+      const nextPublished = !assignment.isPublished;
+      await fetchJson(`/api/assignments/${assignmentId}`, {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ is_locked: assignment.isLocked || !nextPublished }),
+      });
+      const refreshed = await fetchCourseAssignments(courseId);
+      coursesDispatch({ type: "SET_ASSIGNMENTS", courseId, payload: refreshed });
+    },
+    duplicateAssignment: async (courseId, assignment) => {
+      await fetchJson("/api/assignments", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          course_id: courseId,
+          kind: "assignment",
+          title: `${assignment.name} (Copy)`,
+          description: assignment.description || null,
+          is_locked: true,
+          chapter: assignment.chapter || 1,
+          subchapter: assignment.subchapter || "",
+          due_date: assignment.dueDate
+            ? toIsoDateTime(assignment.dueDate, assignment.dueTime || "23:59")
+            : null,
+          late_window_days: assignment.lateWindowDays,
+          late_penalty_percent: assignment.latePenaltyPercent,
+        }),
+      });
+      const refreshed = await fetchCourseAssignments(courseId);
+      coursesDispatch({ type: "SET_ASSIGNMENTS", courseId, payload: refreshed });
+    },
+    deleteAssignment: async (courseId, assignmentId) => {
+      await fetchJson(`/api/assignments/${assignmentId}`, { method: "DELETE" });
+      const refreshed = await fetchCourseAssignments(courseId);
+      coursesDispatch({ type: "SET_ASSIGNMENTS", courseId, payload: refreshed });
+    },
+    updateAssignmentDueDate: async (courseId, assignmentId, dueDate, dueTime) => {
+      await fetchJson(`/api/assignments/${assignmentId}`, {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ due_date: toIsoDateTime(dueDate, dueTime || "23:59") }),
+      });
+      const refreshed = await fetchCourseAssignments(courseId);
+      coursesDispatch({ type: "SET_ASSIGNMENTS", courseId, payload: refreshed });
+    },
+    createPractice: async (courseId, formData) => {
+      const created = await fetchJson("/api/assignments", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(buildPracticePayload(formData, courseId)),
+      });
+      const refreshed = await fetchCoursePractices(courseId);
+      coursesDispatch({ type: "SET_PRACTICES", courseId, payload: refreshed });
+      return created;
+    },
+    updatePractice: async (courseId, practiceId, formData) => {
+      await fetchJson(`/api/assignments/${practiceId}`, {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(buildPracticePayload(formData, courseId)),
+      });
+      const refreshed = await fetchCoursePractices(courseId);
+      coursesDispatch({ type: "SET_PRACTICES", courseId, payload: refreshed });
+    },
+    togglePracticeLock: async (courseId, practiceId, practice) => {
+      await fetchJson(`/api/assignments/${practiceId}`, {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ is_locked: !practice.isLocked }),
+      });
+      const refreshed = await fetchCoursePractices(courseId);
+      coursesDispatch({ type: "SET_PRACTICES", courseId, payload: refreshed });
+    },
+    togglePracticePublish: async (courseId, practiceId, practice) => {
+      const nextPublished = !practice.isPublished;
+      await fetchJson(`/api/assignments/${practiceId}`, {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ is_locked: practice.isLocked || !nextPublished }),
+      });
+      const refreshed = await fetchCoursePractices(courseId);
+      coursesDispatch({ type: "SET_PRACTICES", courseId, payload: refreshed });
+    },
+    duplicatePractice: async (courseId, practice) => {
+      await fetchJson("/api/assignments", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          course_id: courseId,
+          kind: "practice",
+          title: `${practice.name} (Copy)`,
+          description: practice.description || null,
+          is_locked: true,
+          chapter: practice.chapter || 1,
+          subchapter: practice.subchapter || "A",
+          due_date: null,
+          late_window_days: null,
+          late_penalty_percent: null,
+        }),
+      });
+      const refreshed = await fetchCoursePractices(courseId);
+      coursesDispatch({ type: "SET_PRACTICES", courseId, payload: refreshed });
+    },
+    deletePractice: async (courseId, practiceId) => {
+      await fetchJson(`/api/assignments/${practiceId}`, { method: "DELETE" });
+      const refreshed = await fetchCoursePractices(courseId);
+      coursesDispatch({ type: "SET_PRACTICES", courseId, payload: refreshed });
+    },
+    bulkAddStudents: async (courseId, students, existingStudents = []) => {
+      const response = await bulkCreateStudents(courseId, students);
+      const imported = response?.students || [];
+      const newStudents = imported.map((student) => ({
+        id: student.id,
+        username: student.username,
+        grades: {},
+        lateSubmissions: {},
+        submissionDates: {},
+        practices: {},
+      }));
+      const updatedGradebook = [...existingStudents, ...newStudents];
+      coursesDispatch({ type: "SET_GRADEBOOK", courseId, payload: updatedGradebook });
+      coursesDispatch({
+        type: "UPDATE_COURSE_SETTINGS",
+        courseId,
+        payload: { studentCount: updatedGradebook.length },
+      });
+      return newStudents;
+    },
+    updateStudentRole: async (courseId, userId, role, existingStudents = []) => {
+      await updateEnrollmentRole(courseId, userId, role);
+      const updated = existingStudents.map((student) =>
+        student.id === userId ? { ...student, role } : student
+      );
+      coursesDispatch({ type: "SET_GRADEBOOK", courseId, payload: updated });
+      return updated;
+    },
+    getAccommodations: async (courseId, userId) => {
+      const rows = await fetchJson(`/api/instructor/courses/${Number(courseId)}/accommodations`);
+      return (rows || []).filter((row) => row.user_id === userId);
+    },
+    saveAccommodations: async (courseId, userId, payload) => {
+      await fetchJson(`/api/instructor/courses/${Number(courseId)}/accommodations`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ ...payload, user_id: userId }),
+      });
+    },
+    getDeadlines: async (courseId, userId) => {
+      return fetchJson(`/api/instructor/courses/${Number(courseId)}/deadlines/${userId}`);
+    },
+    saveDeadline: async (courseId, assignmentId, userId, extensionDueAt) => {
+      await fetchJson(`/api/instructor/courses/${Number(courseId)}/deadlines`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          user_id: userId,
+          assignment_id: assignmentId,
+          extension_due_at: extensionDueAt,
+        }),
+      });
+    },
+    loadInstructorDashboard: async (courseId) => {
+      const [analytics, summary] = await Promise.all([
+        fetchJson(`/api/analytics/instructor-dashboard?courseId=${courseId}`),
+        fetchJson(`/api/analytics/gradebook-summary?courseId=${courseId}`),
+      ]);
+      return {
+        analytics,
+        gradebookSummary: Array.isArray(summary) ? summary : (summary?.assignments ?? []),
+      };
+    },
+  };
+
+  return {
+    mode: "app",
+    ...runtimePaths,
+    isSandbox: false,
+    remapStudentPath: (path) => remapStudentPath(path, runtimePaths.routePrefix),
+    getBreadcrumbInfo: (pathname) => buildBreadcrumbInfo(pathname, {
+      routeKind,
+      routePrefix: runtimePaths.routePrefix,
+    }),
+    storageScope: "local",
+    user,
+    courses: coursesState.courses,
+    activeCourseId: coursesState.activeCourseId,
+    sandbox: null,
+    instructorSandbox: null,
+    courseState: coursesState,
+    courseActions: runtimeCourseActions,
+  };
+}

--- a/src/runtime/appRuntime.js
+++ b/src/runtime/appRuntime.js
@@ -246,13 +246,12 @@ export function createAppRuntime({ coursesDispatch, coursesState, routeKind, use
       return fetchJson(`/api/instructor/courses/${Number(courseId)}/deadlines/${userId}`);
     },
     saveDeadline: async (courseId, assignmentId, userId, extensionDueAt) => {
-      await fetchJson(`/api/instructor/courses/${Number(courseId)}/deadlines`, {
+      await fetchJson(`/api/instructor/assignments/${assignmentId}/extensions`, {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({
           user_id: userId,
-          assignment_id: assignmentId,
-          extension_due_at: extensionDueAt,
+          extended_due_date: extensionDueAt,
         }),
       });
     },

--- a/src/runtime/sandboxRuntime.js
+++ b/src/runtime/sandboxRuntime.js
@@ -1,0 +1,95 @@
+const studentSectionLabels = {
+  dashboard: "Dashboard",
+  courses: "My Courses",
+  assignments: "Assignments",
+  grades: "Grades",
+  practice: "Practice",
+  contact: "Contact",
+  profile: "Profile & Preferences",
+};
+
+const instructorSectionLabels = {
+  dashboard: "Dashboard",
+  courses: "All Courses",
+  assignments: "Assignments",
+  gradebook: "Gradebook",
+  controls: "Course Controls",
+  contact: "Contact",
+  roster: "Roster",
+  profile: "Profile & Preferences",
+  practice: "Practice",
+};
+
+export function getRoutePrefix(routeKind) {
+  return routeKind === "instructor" ? "/instructor" : "/student";
+}
+
+export function remapRoutePath(path, sourcePrefix, routePrefix) {
+  if (typeof path !== "string") return path;
+  if (path === sourcePrefix) return routePrefix;
+  if (!path.startsWith(`${sourcePrefix}/`)) return path;
+  return `${routePrefix}${path.slice(sourcePrefix.length)}`;
+}
+
+export function remapStudentPath(path, routePrefix = "/student") {
+  return remapRoutePath(path, "/student", routePrefix);
+}
+
+export function buildRuntimePaths(routeKind, routePrefix = getRoutePrefix(routeKind)) {
+  const isInstructor = routeKind === "instructor";
+  const gradesPath = isInstructor ? `${routePrefix}/gradebook` : `${routePrefix}/grades`;
+
+  return {
+    routeKind,
+    routePrefix,
+    isInstructor,
+    dashboardPath: `${routePrefix}/dashboard`,
+    coursesPath: `${routePrefix}/courses`,
+    assignmentsPath: `${routePrefix}/assignments`,
+    gradesPath,
+    gradebookPath: isInstructor ? `${routePrefix}/gradebook` : undefined,
+    practicePath: `${routePrefix}/practice`,
+    contactPath: `${routePrefix}/contact`,
+    profilePath: `${routePrefix}/profile`,
+    rosterPath: isInstructor ? `${routePrefix}/roster` : undefined,
+    controlsPath: isInstructor ? `${routePrefix}/controls` : undefined,
+    assignmentBuilderPath: isInstructor ? `${routePrefix}/assignment-builder` : undefined,
+    assignmentPath: (assignmentId) => `${routePrefix}/assignment/${assignmentId}`,
+  };
+}
+
+export function buildBreadcrumbInfo(pathname, {
+  routeKind,
+  routePrefix = getRoutePrefix(routeKind),
+  stripPrefix = routePrefix,
+}) {
+  const normalizedPath = pathname === stripPrefix
+    ? "/dashboard"
+    : pathname.startsWith(`${stripPrefix}/`)
+    ? pathname.slice(stripPrefix.length) || "/dashboard"
+    : pathname;
+
+  if (normalizedPath.startsWith("/assignment/") || normalizedPath.startsWith("/assignment-builder")) {
+    return {
+      label: "Assignments",
+      path: `${routePrefix}/assignments`,
+    };
+  }
+
+  if (normalizedPath.startsWith("/worksheet/")) {
+    return {
+      label: "Worksheet",
+      path: `${routePrefix}/assignments`,
+    };
+  }
+
+  const [section = "dashboard"] = normalizedPath.split("/").filter(Boolean);
+  const labels = routeKind === "instructor"
+    ? instructorSectionLabels
+    : studentSectionLabels;
+
+  return {
+    label: labels[section] || labels.dashboard,
+    path: `${routePrefix}/${section}`,
+  };
+}


### PR DESCRIPTION
## 🔗 Linked Issue

Closes #30 

## 📝 Description

I extracted shared runtime and layout wiring out of `AppLayout.jsx` into runtime modules and a shared shell frame. Carried the shared follow-up fixes needed to preserve main behavior after the extraction, including assignment and practice ordering, default-expanded sections, the worksheet instructor flag, the shared landing page, the real instructor builder route, and the correct student extension post path.

## 🚀 Type of Change

- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [x] 🛠️ Refactor / Chore (Code cleanup, dependency update, etc.)

## 🧪 How to Test

[Provide clear steps for the reviewer to manually test your UI or API changes.]

1. Pull down this branch and run `npm run dev`
2. Log in as a student and verify `/student/dashboard`, `/student/courses`, `/student/assignments`, `/student/practice`, and `/student/grades` still load and keep the expected ordering and expanded sections
3. Log in as an instructor and verify `/instructor/dashboard`, `/instructor/assignments`, `/instructor/practice`, `/instructor/gradebook`, `/instructor/roster`, and `/instructor/controls` still load inside the shared shell
4. From `/instructor/assignments`, open or create an assignment and verify the real app still routes to the instructor assignment builder 


## ✅ Pre-Merge Checklist

- [x] I have performed a self-review of my own code.
- [x] I have removed all temporary `console.log`s and debuggers.
- [x] I have successfully rebased / resolved any merge conflicts with `main`.
- [x] UI looks good on both desktop and mobile viewports.
