### PR TITLE
use same origin api for auth requests

### DIFF
--- a/src/utils/api.js
+++ b/src/utils/api.js
@@ -1,4 +1,6 @@
-const API_BASE_URL = import.meta.env.VITE_API_BASE_URL || 'https://backend-logic-production.up.railway.app';
+// default to same origin api so production auth cookies are issued for
+// hunterlogic org via the frontend rewrite proxy instead of railway directly
+const API_BASE_URL = import.meta.env.VITE_API_BASE_URL || '';
 const USER_STORAGE_KEY = 'logicapp_current_user';
 let unauthorizedHandler = null;
 
@@ -119,7 +121,7 @@ export async function fetchJson(path, options = {}) {
     try {
       message = JSON.parse(text)?.message || text;
     } catch {
-      // text wasn't json; keep raw message
+      // text was not json keep raw message
     }
     throw new Error(message || `Request failed: ${res.status}`);
   }


### PR DESCRIPTION
## 🔗 Linked Issue

Closes #[Insert issue number here - e.g., Closes #12]

## 📝 Description

Auth requests on the production site are fixed by making the frontend use same origin /api requests by default instead of calling the Railway backend directly. 

## 🚀 Type of Change

- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 🛠️ Refactor / Chore (Code cleanup, dependency update, etc.)

## 🧪 How to Test

[Provide clear steps for the reviewer to manually test your UI or API changes.]

1. Pull down this branch and run `npm run dev`
2. Verify authenticated follow up API requests still work after login

## ✅ Pre-Merge Checklist

- [x] I have performed a self-review of my own code.
- [x] I have removed all temporary `console.log`s and debuggers.
- [x] I have successfully rebased / resolved any merge conflicts with `main`.
- [x] UI looks good on both desktop and mobile viewports.
