### PR TITLE
logged in users redirect to app instead of landing page

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -25,7 +25,7 @@ import InstructorControls from "./pages/instructor/InstructorControls.jsx";
 import InstructorAssignments from "./pages/instructor/InstructorAssignments.jsx";
 import AssignmentBuilder from "./pages/instructor/InstructorAssignmentBuilder.jsx";
 import Login from "./pages/Login.jsx";
-import Landing from "./pages/Landing.jsx";
+import PublicLandingRoute from "./pages/PublicLandingRoute.jsx";
 import Courses from "./pages/Courses.jsx";
 import Profile from "./pages/Profile.jsx";
 import InstructorPractice from "./pages/instructor/InstructorPractice.jsx";
@@ -151,7 +151,7 @@ function AppRoutes() {
       </Route>
 
       <Route element={<AppProviders />}>
-        <Route path="/" element={<Landing />} />
+        <Route path="/" element={<PublicLandingRoute />} />
         <Route path="/login" element={<Login />} />
         <Route
           path="/student"

--- a/src/pages/PublicLandingRoute.jsx
+++ b/src/pages/PublicLandingRoute.jsx
@@ -1,0 +1,42 @@
+import { Navigate } from 'react-router-dom'
+import { Box } from '@mui/material'
+import { useAuthState } from '@/context/AuthContext'
+import { normalizeRole } from '@/utils/auth'
+import LoadingSpinner from '@/components/ui/LoadingSpinner.jsx'
+import Landing from './Landing.jsx'
+
+/**
+ * `/` — landing page for guests; logged-in users go straight to their dashboard.
+ * Session is restored from `localStorage` (`logicapp_current_user`) via `AuthProvider`.
+ */
+export default function PublicLandingRoute() {
+  const { isAuthenticated, user, isLoading } = useAuthState()
+
+  if (isLoading) {
+    return (
+      <Box
+        sx={{
+          display: 'flex',
+          justifyContent: 'center',
+          alignItems: 'center',
+          minHeight: '100vh',
+        }}
+      >
+        <LoadingSpinner label="Loading..." />
+      </Box>
+    )
+  }
+
+  if (isAuthenticated) {
+    const role = normalizeRole(user?.role)
+    if (role === 'instructor') {
+      return <Navigate to="/instructor/dashboard" replace />
+    }
+    if (role === 'student') {
+      return <Navigate to="/student/dashboard" replace />
+    }
+    return <Navigate to="/login" replace />
+  }
+
+  return <Landing />
+}


### PR DESCRIPTION
## 🔗 Linked Issue

Closes #37 

## 📝 Description

This PR bypasses the landing page for logged in users and sends them directly to their respective dashboard (whether they are an instructor or student).
New or logged out users will be able to see the landing page at the root route.

## 🚀 Type of Change

- [ ] 🐛 Bug fix
- [X] ✨ New feature
- [ ] 🛠️ Refactor / Chore (Code cleanup, dependency update, etc.)

## 🧪 How to Test

1. Log out of your HuLA account
2. Visit the root route `.../`
3. Ensure that the landing page is visible and functional
4. Log into your HuLA account
5. Visit the root route `.../`
6. Ensure that landing page is bypassed and you are sent straight to the dashboard

## ✅ Pre-Merge Checklist

- [X] I have performed a self-review of my own code.
- [X] I have removed all temporary `console.log`s and debuggers.
- [X] I have successfully rebased / resolved any merge conflicts with `main`.
- [X] UI looks good on both desktop and mobile viewports.