### PR TITLE
Bug mobile keyboard

### DIFF
--- a/src/components/problems/derivation/DerivationTable.jsx
+++ b/src/components/problems/derivation/DerivationTable.jsx
@@ -1269,9 +1269,11 @@ export default function DerivationTable({
     const inputEl = formulaRefs.current[targetIdx]
     const current = lines[targetIdx]?.formula || ''
     const stored = getStoredSelection(targetIdx, current.length)
+    const activeFacade = targetIdx === activeKeyboardFormulaIndexRef.current && inputEl
     const isFocused = typeof document !== 'undefined' && document.activeElement === inputEl
-    const start = isFocused && typeof inputEl?.selectionStart === 'number' ? inputEl.selectionStart : stored.start
-    const end = isFocused && typeof inputEl?.selectionEnd === 'number' ? inputEl.selectionEnd : stored.end
+    const useInputSelection = activeFacade || isFocused
+    const start = useInputSelection && typeof inputEl?.selectionStart === 'number' ? inputEl.selectionStart : stored.start
+    const end = useInputSelection && typeof inputEl?.selectionEnd === 'number' ? inputEl.selectionEnd : stored.end
     const hasSelection = end > start
     const [open, close] = pair ? pair.split('') : []
     const insertText = pair
@@ -1596,6 +1598,13 @@ export default function DerivationTable({
                       onBlur={() => handleLineCommit(idx, 'formula', normalizeFormulaForCheck(line.formula ?? ''))}
                       placeholder=""
                       aria-label={`Formula line ${idx + 1}`}
+                      inputRef={(el) => { if (el) formulaRefs.current[idx] = el }}
+                      onCursorChange={(position) => {
+                        if (line.readOnly) return
+                        const safePosition = Number.isFinite(position) ? position : 0
+                        const maxPosition = (line.formula ?? '').length
+                        setStoredSelection(idx, Math.max(0, Math.min(safePosition, maxPosition)))
+                      }}
                       includeQuantifiers={derivationKeyboardConfig.isPredicateMode}
                       extraInsertButtons={derivationKeyboardConfig.extraQuantifierButtons}
                       predicateLetters={derivationKeyboardConfig.isPredicateMode ? derivationKeyboardConfig.predicateLetters : undefined}

--- a/src/components/problems/derivation/DerivationTable.jsx
+++ b/src/components/problems/derivation/DerivationTable.jsx
@@ -108,6 +108,32 @@ function getConstantLettersFromPrompt(promptText, count = 3) {
   return result.length > 0 ? result : ['a', 'b', 'c']
 }
 
+function getConstantLettersFromFormulasAndKey(formulaText, symbolizationKey) {
+  const seen = new Set()
+  const result = []
+  const addConstant = (letter) => {
+    if (!seen.has(letter)) {
+      seen.add(letter)
+      result.push(letter)
+    }
+  }
+
+  for (const letter of formulaText.match(/[a-w]/g) || []) {
+    addConstant(letter)
+  }
+
+  for (const line of Array.isArray(symbolizationKey) ? symbolizationKey : []) {
+    const s = typeof line === 'string' ? line : String(line ?? '')
+    const splitAt = s.search(/[=:]/)
+    const left = (splitAt === -1 ? s : s.slice(0, splitAt)).trim()
+    if (/^[a-w]$/.test(left)) {
+      addConstant(left)
+    }
+  }
+
+  return result
+}
+
 const PREDICATE_VARIABLES = ['x', 'y', 'z']
 
 function isPredicateLogicKey(symbolizationKey) {
@@ -500,10 +526,14 @@ export default function DerivationTable({
     const isPredicate = isPredicateLogicKey(key) || /[∀∃]/.test(formulaText)
 
     if (isPredicate) {
-      // For predicate logic, constants should not reuse letters from formulas or symbolization key.
       const keyText = key.map((line) => (typeof line === 'string' ? line : String(line ?? ''))).join(' ')
       const textForConstants = [formulaText, keyText].filter(Boolean).join(' ') || ''
-      const constantLetters = getConstantLettersFromPrompt(textForConstants, 3)
+      const givenConstantLetters = getConstantLettersFromFormulasAndKey(formulaText, key)
+      const fallbackConstantLetters = getConstantLettersFromPrompt(textForConstants, 3)
+      const constantLetters = [
+        ...givenConstantLetters,
+        ...fallbackConstantLetters.filter((letter) => !givenConstantLetters.includes(letter)),
+      ]
       const variableLetters = PREDICATE_VARIABLES
       // Prefer predicate letters from the symbolization key; if missing, fall back to uppercase letters in formulas.
       const fromKey = getPredicateLettersFromKey(key)

--- a/src/components/problems/derivation/DerivationTable.jsx
+++ b/src/components/problems/derivation/DerivationTable.jsx
@@ -118,6 +118,29 @@ function isPredicateLogicKey(symbolizationKey) {
   })
 }
 
+const DEFAULT_QUANTIFIER_INSERTS = new Set(['(∀x)', '(∃x)'])
+
+function getQuantifierButtonsFromFormulas(premises, conclusion) {
+  const formulas = [...(Array.isArray(premises) ? premises : []), conclusion].filter(Boolean).map(String)
+  const text = formulas.join(' ')
+  const seen = new Set(DEFAULT_QUANTIFIER_INSERTS)
+  const buttons = []
+  const matches = text.match(/\(?[∀∃][x-z]\)?/g)
+
+  if (!matches) return buttons
+
+  for (const rawMatch of matches) {
+    const match = rawMatch.match(/[∀∃][x-z]/)
+    if (!match) continue
+    const insert = `(${match[0]})`
+    if (seen.has(insert)) continue
+    seen.add(insert)
+    buttons.push({ label: insert, insert })
+  }
+
+  return buttons
+}
+
 const SYMBOL_BUTTONS = [
   { label: '~', insert: '~' },
   { label: '•', insert: '•' },
@@ -472,6 +495,7 @@ export default function DerivationTable({
     const premises = Array.isArray(proof?.premises) ? proof.premises : []
     const conclusion = proof?.conclusion ?? proof?.conc ?? ''
     const formulaText = [...premises, conclusion].filter(Boolean).map(String).join(' ')
+    const extraQuantifierButtons = getQuantifierButtonsFromFormulas(premises, conclusion)
 
     const isPredicate = isPredicateLogicKey(key) || /[∀∃]/.test(formulaText)
 
@@ -490,6 +514,7 @@ export default function DerivationTable({
         predicateLetters,
         constantLetters,
         variableLetters,
+        extraQuantifierButtons,
       }
     }
 
@@ -498,8 +523,18 @@ export default function DerivationTable({
     return {
       isPredicateMode: false,
       symbolizationKey: predicateLetters,
+      extraQuantifierButtons,
     }
   }, [proof])
+  const symbolButtons = useMemo(() => {
+    const extraQuantifierButtons = derivationKeyboardConfig.extraQuantifierButtons || []
+    if (extraQuantifierButtons.length === 0) return SYMBOL_BUTTONS
+    return [
+      ...SYMBOL_BUTTONS.slice(0, 7),
+      ...extraQuantifierButtons,
+      ...SYMBOL_BUTTONS.slice(7),
+    ]
+  }, [derivationKeyboardConfig.extraQuantifierButtons])
   const isLineCompleteForCheck = useCallback((line) => {
     if (!line) return false
     const formulaFilled = (line.formula || '').trim().length > 0
@@ -1532,6 +1567,7 @@ export default function DerivationTable({
                       placeholder=""
                       aria-label={`Formula line ${idx + 1}`}
                       includeQuantifiers={derivationKeyboardConfig.isPredicateMode}
+                      extraInsertButtons={derivationKeyboardConfig.extraQuantifierButtons}
                       predicateLetters={derivationKeyboardConfig.isPredicateMode ? derivationKeyboardConfig.predicateLetters : undefined}
                       constantLetters={derivationKeyboardConfig.isPredicateMode ? derivationKeyboardConfig.constantLetters : undefined}
                       variableLetters={derivationKeyboardConfig.isPredicateMode ? derivationKeyboardConfig.variableLetters : undefined}
@@ -1898,7 +1934,7 @@ export default function DerivationTable({
                             <AutoAwesomeIcon />
                           </IconButton>
                         </Tooltip>
-                        {SYMBOL_BUTTONS.map(({ label, insert, pair }) => (
+                        {symbolButtons.map(({ label, insert, pair }) => (
                           <Button
                             key={label}
                             type="button"

--- a/src/components/ui/LogicKeyboard/MobileLogicInput.jsx
+++ b/src/components/ui/LogicKeyboard/MobileLogicInput.jsx
@@ -42,6 +42,7 @@ export default function MobileLogicInput({
   onChange,
   onFocus,
   onBlur,
+  onCursorChange,
   inputRef,
   disabled,
   placeholder,
@@ -224,7 +225,10 @@ export default function MobileLogicInput({
         onFocus={handleFocus}
         onBlur={handleBlur}
         cursorPosition={cursorPosition}
-        onCursorChange={setCursorPosition}
+        onCursorChange={(position) => {
+          setCursorPosition(position)
+          onCursorChange?.(position)
+        }}
         disabled={disabled}
         placeholder={placeholder}
         aria-label={ariaLabel}


### PR DESCRIPTION
## 🔗 Linked Issue

Closes #39 & #40 

## 📝 Description

Three derivation keyboard issues are fixed here:

### Dynamic quantifier buttons

Derivation keyboards now parse a problem's given premise(s) and conclusion for quantified variables `x` - `z`. For example, a problem with the premise, `(∀x)[Ax ⊃ (∀y)Bxy]`, now has a corresponding `(∀y)` button.
default quantifier buttons `(∀x)` and `(∃x)` are not duplicated
extra quantifier buttons are added to both the derivation toolbar and the mobile `MobileLogicInput` symbol row

### Given constants on mobile

The predicate derivation keyboard now pulls constants `a` - `w` from the given premise(s) and conclusion of a problem & feeds both the given constants new constants to the mobile keyboard constant row

### Mobile premise symbol insertion
- `MobileLogicInput` accepts `onCursorChange` and reports cursor movement back to the derivation table
- `handleSymbolInsert` prioritizes the active `MobileLogicInput` selection state when inserting tapped symbols from the given premise(s) or conclusion
- tapping a letter in a given premise or conclusion now inserts at the current mobile cursor position instead of falling back to stale stored selection

## 🚀 Type of Change

- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 🛠️ Refactor / Chore (Code cleanup, dependency update, etc.)

## 🧪 How to Test

[Provide clear steps for the reviewer to manually test your UI or API changes.]

1. Pull down this branch and run `npm run dev`
2. Navigate to a predicate logic derivation problem on mobile and desktop
3. Find a problem with a premise that has a non-x variable attached to a quantifier
4. Confirm that variable attached to its quantifier appears in derivation symbol controls
5. Navigate a problem with a constant in its given premise(s) or conclusion, e.g., `Fa`
6. Type a predicate letter, then tap on the constant
7. Confirm the tapped letter inserts at the current cursor position
8. Confirm the constant appears in the mobile keyboard constant row


## ✅ Pre-Merge Checklist

- [x] I have performed a self-review of my own code.
- [x] I have removed all temporary `console.log`s and debuggers.
- [x] I have successfully rebased / resolved any merge conflicts with `main`.
- [x] UI looks good on both desktop and mobile viewports.
