### PR TITLE
Accessibility toggle to turn off mobile keyboard

### DIFF
--- a/src/components/layout/AppLayout.jsx
+++ b/src/components/layout/AppLayout.jsx
@@ -26,8 +26,12 @@ const TEXT_SIZE_OPTIONS = {
 function readTextSize() {
   if (typeof window === "undefined") return "default";
 
-  const savedValue = window.localStorage.getItem(TEXT_SIZE_STORAGE_KEY);
-  return savedValue && TEXT_SIZE_OPTIONS[savedValue] ? savedValue : "default";
+  try {
+    const savedValue = window.localStorage.getItem(TEXT_SIZE_STORAGE_KEY);
+    return savedValue && TEXT_SIZE_OPTIONS[savedValue] ? savedValue : "default";
+  } catch {
+    return "default";
+  }
 }
 
 function applyTextSize(size) {

--- a/src/components/layout/AppLayout.jsx
+++ b/src/components/layout/AppLayout.jsx
@@ -15,6 +15,30 @@ import { AppRuntimeProvider } from "../../context/AppRuntimeContext.jsx";
 import { createAppRuntime } from "../../runtime/appRuntime.js";
 import ShellFrame from "./ShellFrame.jsx";
 
+const TEXT_SIZE_STORAGE_KEY = "logicapp_text_size";
+const TEXT_SIZE_OPTIONS = {
+  smaller: 0.8,
+  default: 1,
+  larger: 1.2,
+  largest: 1.4,
+};
+
+function readTextSize() {
+  if (typeof window === "undefined") return "default";
+
+  const savedValue = window.localStorage.getItem(TEXT_SIZE_STORAGE_KEY);
+  return savedValue && TEXT_SIZE_OPTIONS[savedValue] ? savedValue : "default";
+}
+
+function applyTextSize(size) {
+  if (typeof document === "undefined") return;
+
+  const scale = TEXT_SIZE_OPTIONS[size] || TEXT_SIZE_OPTIONS.default;
+
+  // the whole app listens at the root
+  document.documentElement.style.fontSize = `${80 * scale}%`;
+}
+
 function AppShell({ children }) {
   const location = useLocation();
   const navigate = useNavigate();
@@ -24,12 +48,25 @@ function AppShell({ children }) {
   const coursesState = useCoursesState();
   const { initialized } = coursesState;
   const [isAccountSettingsOpen, setIsAccountSettingsOpen] = useState(false);
+  const [textSize, setTextSize] = useState(readTextSize);
 
   useEffect(() => {
     if (user?.role && user?.id && !initialized) {
       initializeCourses(coursesDispatch);
     }
   }, [user?.role, user?.id, initialized, coursesDispatch]);
+
+  useEffect(() => {
+    applyTextSize(textSize);
+
+    if (typeof window === "undefined") return;
+
+    try {
+      window.localStorage.setItem(TEXT_SIZE_STORAGE_KEY, textSize);
+    } catch {
+      // storage can fail and we move on
+    }
+  }, [textSize]);
 
   const isInstructorRoute = location.pathname.startsWith("/instructor")
     ? true
@@ -73,6 +110,8 @@ function AppShell({ children }) {
         showAccountSettings
         isAccountSettingsOpen={isAccountSettingsOpen}
         onCloseAccountSettings={() => setIsAccountSettingsOpen(false)}
+        textSize={textSize}
+        onTextSizeChange={setTextSize}
       >
         {children}
       </ShellFrame>

--- a/src/components/layout/Header.jsx
+++ b/src/components/layout/Header.jsx
@@ -14,7 +14,6 @@ import {
   Menu as MenuIcon,
   MenuBook as MenuBookIcon,
   ArrowBack as ArrowBackIcon,
-  Settings as SettingsIcon,
 } from "@mui/icons-material";
 import { ChevronRight } from "lucide-react";
 import { Link as RouterLink, useLocation } from "react-router-dom";
@@ -28,7 +27,7 @@ import {
 } from "../../context/LayoutContext.jsx";
 import { useAppRuntime } from "../../hooks/useAppRuntime.js";
 
-export default function Header({ onSignOut, onOpenSettings }) {
+export default function Header({ onSignOut }) {
   const location = useLocation();
   const { courses, activeCourseId, coursesPath, getBreadcrumbInfo, isSandbox: sandbox } = useAppRuntime();
   const layoutDispatch = useLayoutDispatch();
@@ -143,15 +142,6 @@ export default function Header({ onSignOut, onOpenSettings }) {
             Rulebook
           </Button>
           <ThemeToggle />
-          {isMobile && onOpenSettings && (
-            <IconButton
-              aria-label="Open settings"
-              onClick={onOpenSettings}
-              color="inherit"
-            >
-              <SettingsIcon />
-            </IconButton>
-          )}
         </Box>
       </Toolbar>
     </AppBar>

--- a/src/components/layout/Header.jsx
+++ b/src/components/layout/Header.jsx
@@ -10,7 +10,12 @@ import {
   useMediaQuery,
   useTheme,
 } from "@mui/material";
-import { Menu as MenuIcon, MenuBook as MenuBookIcon, ArrowBack as ArrowBackIcon } from "@mui/icons-material";
+import {
+  Menu as MenuIcon,
+  MenuBook as MenuBookIcon,
+  ArrowBack as ArrowBackIcon,
+  Settings as SettingsIcon,
+} from "@mui/icons-material";
 import { ChevronRight } from "lucide-react";
 import { Link as RouterLink, useLocation } from "react-router-dom";
 import ThemeToggle from "./ThemeToggle.jsx";
@@ -23,7 +28,7 @@ import {
 } from "../../context/LayoutContext.jsx";
 import { useAppRuntime } from "../../hooks/useAppRuntime.js";
 
-export default function Header({ onSignOut }) {
+export default function Header({ onSignOut, onOpenSettings }) {
   const location = useLocation();
   const { courses, activeCourseId, coursesPath, getBreadcrumbInfo, isSandbox: sandbox } = useAppRuntime();
   const layoutDispatch = useLayoutDispatch();
@@ -138,6 +143,15 @@ export default function Header({ onSignOut }) {
             Rulebook
           </Button>
           <ThemeToggle />
+          {isMobile && onOpenSettings && (
+            <IconButton
+              aria-label="Open settings"
+              onClick={onOpenSettings}
+              color="inherit"
+            >
+              <SettingsIcon />
+            </IconButton>
+          )}
         </Box>
       </Toolbar>
     </AppBar>

--- a/src/components/layout/ShellFrame.jsx
+++ b/src/components/layout/ShellFrame.jsx
@@ -75,7 +75,7 @@ export default function ShellFrame({
           onOpenSettings={onOpenSettings}
         />
         <Box sx={{ display: "flex", flexDirection: "column", flexGrow: 1, minWidth: 0 }}>
-          <Header onSignOut={onSignOut} onOpenSettings={onOpenSettings} />
+          <Header onSignOut={onSignOut} />
           <Box
             component="main"
             ref={mainContentRef}

--- a/src/components/layout/ShellFrame.jsx
+++ b/src/components/layout/ShellFrame.jsx
@@ -15,6 +15,8 @@ export default function ShellFrame({
   showAccountSettings = false,
   isAccountSettingsOpen = false,
   onCloseAccountSettings,
+  textSize = "default",
+  onTextSizeChange,
 }) {
   const { isRulesReferenceOpen } = useLayoutState();
   const mainContentRef = useRef(null);
@@ -98,6 +100,8 @@ export default function ShellFrame({
         <AccountSettingsDialog
           open={isAccountSettingsOpen}
           onClose={onCloseAccountSettings}
+          textSize={textSize}
+          onTextSizeChange={onTextSizeChange}
         />
       )}
       <RulesReference />

--- a/src/components/layout/ShellFrame.jsx
+++ b/src/components/layout/ShellFrame.jsx
@@ -75,7 +75,7 @@ export default function ShellFrame({
           onOpenSettings={onOpenSettings}
         />
         <Box sx={{ display: "flex", flexDirection: "column", flexGrow: 1, minWidth: 0 }}>
-          <Header onSignOut={onSignOut} />
+          <Header onSignOut={onSignOut} onOpenSettings={onOpenSettings} />
           <Box
             component="main"
             ref={mainContentRef}

--- a/src/components/layout/Sidebar.jsx
+++ b/src/components/layout/Sidebar.jsx
@@ -14,7 +14,6 @@ import {
   Avatar,
   Menu,
   MenuItem,
-  Divider,
 } from "@mui/material";
 import {
   ChevronLeft as ChevronLeftIcon,
@@ -118,8 +117,10 @@ export default function Sidebar({ structure, location, onSignOut, onOpenSettings
           willChange: "width, transform",
           display: "flex",
           flexDirection: "column",
-          height: "100vh",
+          height: { xs: "100dvh", md: "100vh" },
+          maxHeight: { xs: "100dvh", md: "100vh" },
           overflowX: "hidden",
+          overflowY: "hidden",
           borderRight: "1px solid",
           borderColor: "divider",
           boxSizing: "border-box",
@@ -155,7 +156,15 @@ export default function Sidebar({ structure, location, onSignOut, onOpenSettings
 
       <CourseSelector isSidebarOpened={isSidebarOpened} />
 
-      <Box sx={{ display: "flex", flexDirection: "column", flexGrow: 1, minHeight: 0 }}>
+      <Box
+        sx={{
+          display: "flex",
+          flexDirection: "column",
+          flexGrow: 1,
+          minHeight: 0,
+          overflow: "hidden",
+        }}
+      >
         <List sx={{ mt: 1, px: 1, flexGrow: 1, minHeight: 0, overflowY: "auto" }}>
           {structure.map((link) => (
             <SidebarLink
@@ -169,9 +178,21 @@ export default function Sidebar({ structure, location, onSignOut, onOpenSettings
           ))}
         </List>
 
-        <Box sx={{ px: 1, pb: 2 }}>
-          <Divider sx={{ mb: 1 }} />
-
+        <Box
+          sx={{
+            px: 1,
+            pt: 1,
+            pb: isMobile ? "max(16px, env(safe-area-inset-bottom, 0px))" : 2,
+            mt: "auto",
+            flexShrink: 0,
+            backgroundColor: "background.paper",
+            borderTop: "1px solid",
+            borderColor: "divider",
+            position: "sticky",
+            bottom: 0,
+            zIndex: 1,
+          }}
+        >
           {!sidebarHoverEnabled && (
             <ListItem disablePadding>
               <ListItemButton

--- a/src/components/layout/Sidebar.jsx
+++ b/src/components/layout/Sidebar.jsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from "react";
+import { useState, useEffect, useRef } from "react";
 import {
   Drawer,
   IconButton,
@@ -37,6 +37,7 @@ export default function Sidebar({ structure, location, onSignOut, onOpenSettings
   const { isSidebarOpened, sidebarHoverEnabled } = useLayoutState();
   const { user: activeUser, isSandbox: sandbox } = useAppRuntime();
   const layoutDispatch = useLayoutDispatch();
+  const drawerPaperRef = useRef(null);
   const [isPermanent, setPermanent] = useState(true);
   const [profileMenu, setProfileMenu] = useState(null);
   const [isHovering, setIsHovering] = useState(false);
@@ -53,6 +54,14 @@ export default function Sidebar({ structure, location, onSignOut, onOpenSettings
   }, [theme.breakpoints.values.md]);
 
   const handleDrawerToggle = () => {
+    if (!isPermanent && isSidebarOpened) {
+      const activeElement = document.activeElement;
+      if (activeElement instanceof HTMLElement && drawerPaperRef.current?.contains(activeElement)) {
+        // let focus leave before the drawer goes dark
+        activeElement.blur();
+      }
+    }
+
     if (sidebarHoverEnabled) {
       setManuallyOpened(!manuallyOpened);
       toggleSidebar(layoutDispatch);
@@ -101,6 +110,11 @@ export default function Sidebar({ structure, location, onSignOut, onOpenSettings
       onClose={handleDrawerToggle}
       onMouseEnter={handleMouseEnter}
       onMouseLeave={handleMouseLeave}
+      slotProps={{
+        paper: {
+          ref: drawerPaperRef,
+        },
+      }}
       sx={{
         width: isSidebarOpened ? DRAWER_WIDTH : 85,
         flexShrink: 0,

--- a/src/components/problems/derivation/DerivationTable.jsx
+++ b/src/components/problems/derivation/DerivationTable.jsx
@@ -161,11 +161,22 @@ const RULES_ALLOW_NO_LINES = new Set(['ACP', 'AIP'])
 const ASSUMPTION_RULES = new Set(['ACP', 'AIP'])
 const INDENT_START_RULES = new Set(['ACP', 'AIP'])
 const INDENT_END_RULES = new Set(['CP', 'IP'])
-const INDENT_PX = 18
-const ASSUMPTION_INDENT_PX = 12
 const MAX_INDENT_LEVEL = 3
 const AUTO_CHECK_STORAGE_KEY = 'logic-app:autocheck-enabled'
 const RULE_INPUT_MODE_KEY = 'logic-app:derivation-rule-input-mode'
+
+// the line sizes follow the root scale
+const DERIVATION_LINE_FONT_SIZE = '1.25rem'
+const DERIVATION_NUMBER_CELL_WIDTH_MOBILE = '2.8125rem'
+const DERIVATION_NUMBER_CELL_WIDTH_DESKTOP = '3.75rem'
+const DERIVATION_FORMULA_MIN_WIDTH = '15.625rem'
+const DERIVATION_FORMULA_WIDTH = '21.875rem'
+const DERIVATION_RULE_WIDTH_MOBILE = '4.375rem'
+const DERIVATION_RULE_WIDTH_DESKTOP = '5.46875rem'
+const DERIVATION_JUSTIFICATION_WIDTH_XS = 'calc(7ch + 4.375rem)'
+const DERIVATION_JUSTIFICATION_WIDTH_SM = 'calc(7ch + 5.46875rem)'
+const DERIVATION_INDENT_STEP = '1.40625rem'
+const DERIVATION_ASSUMPTION_OFFSET = '0.9375rem'
 
 // Message shown on mobile when derivation is not fullscreen (table not rendered)
 const MOBILE_DERIVATION_PLACEHOLDER_MSG = 'Tap to open proof'
@@ -1369,7 +1380,7 @@ export default function DerivationTable({
         )}
         {proof.description && !isFullScreen && !hideActions && (
           <Box sx={{ mb: 2, display: 'flex', alignItems: 'flex-start', gap: 0.5 }}>
-            <PromptText content={proof.description} sx={{ fontSize: 15, flex: 1 }} />
+            <PromptText content={proof.description} sx={{ fontSize: '1.171875rem', flex: 1 }} />
           </Box>
         )}
         {isPhone && !isFullScreen && canOpenFullScreen ? (
@@ -1386,7 +1397,7 @@ export default function DerivationTable({
               borderRadius: 2,
               bgcolor: (t) => alpha(t.palette.primary.main, 0.04),
               color: 'primary.main',
-              fontSize: '15px',
+              fontSize: '1.171875rem',
               lineHeight: 2,
               fontWeight: 400,
               cursor: 'pointer',
@@ -1450,7 +1461,7 @@ export default function DerivationTable({
                     '& td:last-child': { paddingRight: '0 !important' },
                     '& .MuiTableCell-root:last-child': { paddingRight: '0 !important' },
                   }
-                : { width: 'auto', minWidth: isMobile ? 200 : 280 }
+                : { width: 'auto', minWidth: isMobile ? DERIVATION_FORMULA_MIN_WIDTH : DERIVATION_FORMULA_WIDTH }
             }
           >
             <TableBody>
@@ -1465,7 +1476,7 @@ export default function DerivationTable({
                   },
                 }}
               >
-                <TableCell sx={{ width: isFullScreen || isMobile ? 36 : 48, minWidth: isFullScreen || isMobile ? 36 : undefined, borderBottom: 'none', verticalAlign: 'middle', ...(isFullScreen && { pr: 1 }) }}>
+                <TableCell sx={{ width: isFullScreen || isMobile ? DERIVATION_NUMBER_CELL_WIDTH_MOBILE : DERIVATION_NUMBER_CELL_WIDTH_DESKTOP, minWidth: isFullScreen || isMobile ? DERIVATION_NUMBER_CELL_WIDTH_MOBILE : undefined, borderBottom: 'none', verticalAlign: 'middle', ...(isFullScreen && { pr: 1 }) }}>
                   <Typography sx={{ color: 'transparent' }}>—</Typography>
                 </TableCell>
                 <TableCell sx={{ borderBottom: 'none', pl: isFullScreen ? 1 : undefined, pr: 0.5, verticalAlign: 'middle', ...(isFullScreen ? { width: '50%', minWidth: 0 } : { width: 'auto', whiteSpace: 'nowrap' }) }}>
@@ -1474,7 +1485,7 @@ export default function DerivationTable({
                 <TableCell sx={{ borderBottom: 'none', pl: 0.5, verticalAlign: 'middle', ...(isFullScreen ? { width: '50%', minWidth: 0 } : { width: 'auto', whiteSpace: 'nowrap' }) }}>
                   <Box
                     component="span"
-                    sx={{ fontSize: 16, color: 'text.primary', '& .clickable-char': { cursor: 'pointer', borderRadius: 1, '&:hover': { backgroundColor: (t) => alpha(t.palette.primary.main, t.palette.action.hoverOpacity) } } }}
+                    sx={{ fontSize: DERIVATION_LINE_FONT_SIZE, color: 'text.primary', '& .clickable-char': { cursor: 'pointer', borderRadius: 1, '&:hover': { backgroundColor: (t) => alpha(t.palette.primary.main, t.palette.action.hoverOpacity) } } }}
                   >
                     {(`// ${proof.conclusion || ''}`).split('').map((char, i) => {
                       const isLetter = /^[a-zA-Z]$/.test(char)
@@ -1492,13 +1503,12 @@ export default function DerivationTable({
             )}
             {lines.map((line, idx) => {
               const isActiveLine = activeFormulaIndex === idx
-              const indentPx = (indentLevels[idx] || 0) * INDENT_PX
-                + (indentLevels[idx] ? ASSUMPTION_INDENT_PX : 0)
+              const indentOffset = `calc(${indentLevels[idx] || 0} * ${DERIVATION_INDENT_STEP}${indentLevels[idx] ? ` + ${DERIVATION_ASSUMPTION_OFFSET}` : ''})`
               return (
               <TableRow
                 key={`line-${idx}`}
                 sx={{
-                  transform: indentPx ? `translateX(${indentPx}px)` : 'none',
+                  transform: indentLevels[idx] ? `translateX(${indentOffset})` : 'none',
                   transition: 'transform 120ms ease',
                   '& td': {
                     py: isMobile ? 0.25 : 0.5,
@@ -1523,7 +1533,7 @@ export default function DerivationTable({
                   }),
                 }}
               >
-                <TableCell sx={{ width: isFullScreen || isMobile ? 36 : 48, minWidth: isFullScreen || isMobile ? 36 : undefined, borderBottom: 'none', color: (t) => alpha(t.palette.text.primary, t.palette.mode === 'dark' ? 0.78 : 0.7), fontWeight: 600, verticalAlign: 'middle', ...(isFullScreen && { pr: 1 }) }}>
+                <TableCell sx={{ width: isFullScreen || isMobile ? DERIVATION_NUMBER_CELL_WIDTH_MOBILE : DERIVATION_NUMBER_CELL_WIDTH_DESKTOP, minWidth: isFullScreen || isMobile ? DERIVATION_NUMBER_CELL_WIDTH_MOBILE : undefined, borderBottom: 'none', color: (t) => alpha(t.palette.text.primary, t.palette.mode === 'dark' ? 0.78 : 0.7), fontWeight: 600, verticalAlign: 'middle', ...(isFullScreen && { pr: 1 }) }}>
                   <Box
                     component="button"
                     type="button"
@@ -1563,7 +1573,7 @@ export default function DerivationTable({
                               WebkitOverflowScrolling: 'touch',
                             }
                           : {}),
-                        fontSize: 16,
+                        fontSize: DERIVATION_LINE_FONT_SIZE,
                         py: isMobile ? 0.5 : 1,
                         ...getInputUnderlineSx(theme),
                         '& .clickable-char': {
@@ -1674,11 +1684,11 @@ export default function DerivationTable({
                       updateCursorPosition(idx, e)
                     }}
                     sx={(theme) => ({
-                      width: isFullScreen ? '100%' : { xs: '100%', md: 280 },
+                      width: isFullScreen ? '100%' : { xs: '100%', md: DERIVATION_FORMULA_WIDTH },
                       minWidth: isFullScreen ? 0 : undefined,
                       ...getInputUnderlineSx(theme),
                       '& .MuiInputBase-input': {
-                        fontSize: 16,
+                        fontSize: DERIVATION_LINE_FONT_SIZE,
                         py: isMobile ? 0.5 : 1,
                       },
                     })}
@@ -1704,7 +1714,7 @@ export default function DerivationTable({
                     idx === premises.length - 1 ? (
                       <Box
                         component="span"
-                        sx={{ fontSize: 16, color: 'text.primary', '& .clickable-char': { cursor: 'pointer', borderRadius: 1, '&:hover': { backgroundColor: (t) => alpha(t.palette.primary.main, t.palette.action.hoverOpacity) } } }}
+                        sx={{ fontSize: DERIVATION_LINE_FONT_SIZE, color: 'text.primary', '& .clickable-char': { cursor: 'pointer', borderRadius: 1, '&:hover': { backgroundColor: (t) => alpha(t.palette.primary.main, t.palette.action.hoverOpacity) } } }}
                       >
                         {(proof?.conclusion ? `// ${proof.conclusion}` : '').split('').map((char, i) => {
                           const isLetter = /^[a-zA-Z]$/.test(char)
@@ -1780,14 +1790,14 @@ export default function DerivationTable({
                                 minWidth: '7ch',
                                 ...getInputUnderlineSx(theme),
                                 '& .MuiInputBase-input': {
-                                  fontSize: 16,
+                                  fontSize: DERIVATION_LINE_FONT_SIZE,
                                   py: isMobile ? 0.5 : 1,
                                 },
                               })}
                             />
                           )}
                           {allowedRules.length > 0 && (
-                            <FormControl variant="standard" sx={{ minWidth: isFullScreen || isMobile ? 56 : 70 }}>
+                            <FormControl variant="standard" sx={{ minWidth: isFullScreen || isMobile ? DERIVATION_RULE_WIDTH_MOBILE : DERIVATION_RULE_WIDTH_DESKTOP }}>
                               <Select
                                 value={getRuleFromJustification(line.justification)}
                                 displayEmpty
@@ -1842,13 +1852,13 @@ export default function DerivationTable({
                                 }}
                                 renderValue={(value) => value || 'Rule'}
                                 sx={(theme) => ({
-                                  '& .MuiSelect-select': { fontSize: 16, py: isMobile ? 0.5 : 1 },
-                                  '& .MuiInputBase-input': { fontSize: 16, py: isMobile ? 0.5 : 1 },
+                                  '& .MuiSelect-select': { fontSize: DERIVATION_LINE_FONT_SIZE, py: isMobile ? 0.5 : 1 },
+                                  '& .MuiInputBase-input': { fontSize: DERIVATION_LINE_FONT_SIZE, py: isMobile ? 0.5 : 1 },
                                   '& .MuiSelect-select.MuiInputBase-input': { display: 'flex', alignItems: 'center' },
                                   ...getSelectUnderlineSx(theme),
                                 })}
                                 MenuProps={{
-                                  PaperProps: { sx: { '& .MuiMenuItem-root': { fontSize: 16 } } }
+                                  PaperProps: { sx: { '& .MuiMenuItem-root': { fontSize: DERIVATION_LINE_FONT_SIZE } } }
                                 }}
                               >
                                 <MenuItem value="">
@@ -1896,12 +1906,12 @@ export default function DerivationTable({
                           inputProps={{ autoComplete: 'off' }}
                           inputRef={(el) => { if (el) justRefs.current[idx] = el }}
                           sx={(theme) => ({
-                            width: { xs: 'calc(7ch + 56px)', sm: 'calc(7ch + 70px)' },
-                            maxWidth: { xs: 'calc(7ch + 56px)', sm: 'calc(7ch + 70px)' },
-                            minWidth: { xs: 'calc(7ch + 56px)', sm: 'calc(7ch + 70px)' },
+                            width: { xs: DERIVATION_JUSTIFICATION_WIDTH_XS, sm: DERIVATION_JUSTIFICATION_WIDTH_SM },
+                            maxWidth: { xs: DERIVATION_JUSTIFICATION_WIDTH_XS, sm: DERIVATION_JUSTIFICATION_WIDTH_SM },
+                            minWidth: { xs: DERIVATION_JUSTIFICATION_WIDTH_XS, sm: DERIVATION_JUSTIFICATION_WIDTH_SM },
                             ...getInputUnderlineSx(theme),
                             '& .MuiInputBase-input': {
-                              fontSize: 16,
+                              fontSize: DERIVATION_LINE_FONT_SIZE,
                               py: isMobile ? 0.5 : 1,
                             },
                           })}
@@ -1932,7 +1942,7 @@ export default function DerivationTable({
               )
             })}
             <TableRow sx={{ '& td': { verticalAlign: 'middle', py: isMobile ? 0.25 : 0.5 } }}>
-              <TableCell sx={{ width: isFullScreen || isMobile ? 36 : 48, minWidth: isFullScreen || isMobile ? 36 : undefined, borderBottom: 'none', verticalAlign: 'middle', ...(isFullScreen && { pr: 1 }) }}>
+              <TableCell sx={{ width: isFullScreen || isMobile ? DERIVATION_NUMBER_CELL_WIDTH_MOBILE : DERIVATION_NUMBER_CELL_WIDTH_DESKTOP, minWidth: isFullScreen || isMobile ? DERIVATION_NUMBER_CELL_WIDTH_MOBILE : undefined, borderBottom: 'none', verticalAlign: 'middle', ...(isFullScreen && { pr: 1 }) }}>
                 <Tooltip title="New line">
                   <span style={{ display: 'inline-flex' }}>
                     <IconButton onClick={addLine} size="small" aria-label="Add line" disabled={!canAddLine}>

--- a/src/components/problems/derivation/DerivationTable.jsx
+++ b/src/components/problems/derivation/DerivationTable.jsx
@@ -28,7 +28,7 @@ import { alpha } from '@mui/material/styles'
 import PromptText from '../../ui/PromptText.jsx'
 import ThemedCard from '../../ui/ThemedCard.jsx'
 import ProblemSetButtons from '../mui/frame/ProblemSetButtons.jsx'
-import { MobileLogicInput } from '../../ui/LogicKeyboard/index.js'
+import { MobileLogicInput, useMobileLogicKeyboardEnabled } from '../../ui/LogicKeyboard/index.js'
 import checkDerivation from '../../../lib/logicpenguin/checkers/derivation-hurley.js'
 import getHurleyRuleset from '../../../lib/logicpenguin/checkers/rules/hurley-rules.js'
 import getFormulaClass from '../../../lib/logicpenguin/symbolic/formula.js'
@@ -437,6 +437,7 @@ export default function DerivationTable({
 }) {
   const formulaRefs = useRef({})
   const justRefs = useRef({})
+  const mobileLogicKeyboardEnabled = useMobileLogicKeyboardEnabled()
   const [activeFormulaIndex, setActiveFormulaIndex] = useState(null)
   const activeKeyboardFormulaIndexRef = useRef(null)
   const lastFormulaIndexRef = useRef(null)
@@ -1590,7 +1591,7 @@ export default function DerivationTable({
                         )
                       })}
                     </Box>
-                  ) : isPhone ? (
+                  ) : isPhone && mobileLogicKeyboardEnabled ? (
                     <MobileLogicInput
                       value={line.formula ?? ''}
                       onChange={(v) => handleLineChange(idx, 'formula', v)}
@@ -1945,40 +1946,41 @@ export default function DerivationTable({
                   <Box
                     sx={{
                       display: 'flex',
-                      alignItems: 'center',
+                      alignItems: mobileLogicKeyboardEnabled ? 'center' : 'flex-start',
                       gap: isFullScreen ? 0.5 : 0.75,
-                      flexWrap: isFullScreen ? 'wrap' : 'nowrap',
                       minWidth: isFullScreen ? 0 : 'max-content',
+                      width: isPhone && isFullScreen ? '100%' : undefined,
                       pr: isFullScreen ? 0 : 1,
-                      ...(isPhone && isFullScreen && { flexDirection: 'column', alignItems: 'flex-start' }), // two rows only in mobile fullscreen
+                      ...(isPhone && isFullScreen && mobileLogicKeyboardEnabled && {
+                        flexDirection: 'column',
+                        alignItems: 'flex-start',
+                      }),
                     }}
                   >
-                    {isPhone && isFullScreen ? (
-                      <Tooltip title={autoCheckEnabled ? 'Turn off autochecker' : 'Turn on autochecker'}>
-                        <IconButton
-                          onClick={() => setAutoCheckEnabled((prev) => !prev)}
-                          size="small"
-                          aria-label="Toggle autochecker"
-                          sx={{ color: autoCheckEnabled ? 'primary.main' : 'text.disabled', position: 'relative' }}
-                        >
-                          <AutoAwesomeIcon />
-                        </IconButton>
-                      </Tooltip>
-                    ) : (
-                      <>
-                        <Tooltip title={autoCheckEnabled ? 'Turn off autochecker' : 'Turn on autochecker'}>
-                          <IconButton
-                            onClick={() => setAutoCheckEnabled((prev) => !prev)}
-                            size="small"
-                            aria-label="Toggle autochecker"
-                            sx={{
-                              color: autoCheckEnabled ? 'primary.main' : 'text.disabled',
-                              position: 'relative',
-                            }}
-                          >
-                            <AutoAwesomeIcon />
-                          </IconButton>
-                        </Tooltip>
+                    <Tooltip title={autoCheckEnabled ? 'Turn off autochecker' : 'Turn on autochecker'}>
+                      <IconButton
+                        onClick={() => setAutoCheckEnabled((prev) => !prev)}
+                        size="small"
+                        aria-label="Toggle autochecker"
+                        sx={{
+                          color: autoCheckEnabled ? 'primary.main' : 'text.disabled',
+                          position: 'relative',
+                        }}
+                      >
+                        <AutoAwesomeIcon />
+                      </IconButton>
+                    </Tooltip>
+                    {!(isPhone && isFullScreen && mobileLogicKeyboardEnabled) && (
+                      <Box
+                        sx={{
+                          display: 'flex',
+                          alignItems: 'center',
+                          gap: isFullScreen ? 0.5 : 0.75,
+                          flexWrap: isFullScreen ? 'wrap' : 'nowrap',
+                          minWidth: 0,
+                          flex: 1,
+                        }}
+                      >
                         {SYMBOL_BUTTONS.map(({ label, insert, pair }) => (
                           <Button
                             key={label}
@@ -1994,7 +1996,7 @@ export default function DerivationTable({
                             {label}
                           </Button>
                         ))}
-                      </>
+                      </Box>
                     )}
                   </Box>
                 </Stack>

--- a/src/components/problems/derivation/DerivationWorkspace.jsx
+++ b/src/components/problems/derivation/DerivationWorkspace.jsx
@@ -59,7 +59,7 @@ export default function DerivationWorkspace({
       )}
       {prompt && !isFullScreen && (
         <Box sx={{ mb: 0.75, display: 'flex', alignItems: 'flex-start', gap: 0.5 }}>
-          <PromptText content={prompt} sx={{ fontSize: 15, flex: 1 }} />
+          <PromptText content={prompt} sx={{ fontSize: '1.171875rem', flex: 1 }} />
         </Box>
       )}
       {isPhone && !isFullScreen && canOpenFullScreen ? (
@@ -76,7 +76,7 @@ export default function DerivationWorkspace({
             borderRadius: 2,
             bgcolor: (theme) => alpha(theme.palette.primary.main, 0.04),
             color: 'primary.main',
-            fontSize: '15px',
+            fontSize: '1.171875rem',
             lineHeight: 2,
             fontWeight: 400,
             cursor: 'pointer',

--- a/src/components/problems/mui/inputs/FormulaField.jsx
+++ b/src/components/problems/mui/inputs/FormulaField.jsx
@@ -33,6 +33,7 @@ const FormulaField = forwardRef(function FormulaField({
         symbolizationKey={symbolizationKey}
         includeQuantifiers={includeQuantifiers}
         extraInsertButtons={extraInsertButtons}
+        onEnterKey={onEnterKey}
         predicateLetters={predicateLetters}
         constantLetters={constantLetters}
         variableLetters={variableLetters}

--- a/src/components/problems/mui/translation/SymbolicTranslation.jsx
+++ b/src/components/problems/mui/translation/SymbolicTranslation.jsx
@@ -291,6 +291,7 @@ export default function SymbolicTranslation({
                   aria-label="Formula translation"
                   symbolizationKey={symbolizationKey}
                   includeQuantifiers={isPredicate}
+                  onEnterKey={!readOnly && !hideActions ? handleCheck : undefined}
                   predicateLetters={isPredicate ? predicateLetters : undefined}
                   constantLetters={isPredicate ? constantLetters : undefined}
                   variableLetters={isPredicate ? variableLetters : undefined}

--- a/src/components/ui/AccountSettingsDialog.jsx
+++ b/src/components/ui/AccountSettingsDialog.jsx
@@ -3,6 +3,7 @@ import {
   Alert,
   Box,
   Button,
+  ButtonGroup,
   Dialog,
   DialogActions,
   DialogContent,
@@ -98,7 +99,12 @@ const getErrorMessage = (error) => {
   return message;
 };
 
-export default function AccountSettingsDialog({ open, onClose }) {
+export default function AccountSettingsDialog({
+  open,
+  onClose,
+  textSize = "default",
+  onTextSizeChange,
+}) {
   const { user } = useAuthState();
   const [mobileKeyboardEnabled, setMobileKeyboardEnabled] = useState(
     () => !getDesktopKeyboardOnMobile()
@@ -530,6 +536,64 @@ export default function AccountSettingsDialog({ open, onClose }) {
                   </Box>
                 </Box>
               </Stack>
+            </Box>
+
+            <Divider sx={{ my: 1 }} />
+
+            <Box>
+              <Typography variant="h6" sx={{ mb: 1 }}>
+                Display and Text Size
+              </Typography>
+                <Typography variant="body1" sx={{ fontWeight: 500 }}>
+                  Text Size
+                </Typography>
+              <Typography
+                variant="body2"
+                color="text.secondary"
+                sx={{ mt: 0.5, mb: 1.5 }}
+              >
+                Increase or decrease text across the app
+              </Typography>
+              <Box
+                sx={{
+                  display: "flex",
+                  alignItems: "center",
+                  justifyContent: "flex-start",
+                  gap: 2,
+                  flexWrap: "wrap",
+                }}
+              >
+                <ButtonGroup variant="outlined" aria-label="text size controls">
+                  <Button
+                    onClick={() => onTextSizeChange?.("smaller")}
+                    variant={textSize === "smaller" ? "contained" : "outlined"}
+                    sx={{ textTransform: "none" }}
+                  >
+                    smaller
+                  </Button>
+                  <Button
+                    onClick={() => onTextSizeChange?.("default")}
+                    variant={textSize === "default" ? "contained" : "outlined"}
+                    sx={{ textTransform: "none" }}
+                  >
+                    default
+                  </Button>
+                  <Button
+                    onClick={() => onTextSizeChange?.("larger")}
+                    variant={textSize === "larger" ? "contained" : "outlined"}
+                    sx={{ textTransform: "none" }}
+                  >
+                    larger
+                  </Button>
+                  <Button
+                    onClick={() => onTextSizeChange?.("largest")}
+                    variant={textSize === "largest" ? "contained" : "outlined"}
+                    sx={{ textTransform: "none" }}
+                  >
+                    largest
+                  </Button>
+                </ButtonGroup>
+              </Box>
             </Box>
 
             <Divider sx={{ my: 1 }} />

--- a/src/components/ui/AccountSettingsDialog.jsx
+++ b/src/components/ui/AccountSettingsDialog.jsx
@@ -136,8 +136,33 @@ export default function AccountSettingsDialog({ open, onClose }) {
       setLogoutSuccess(false);
       setLogoutError("");
       setLogoutDialogOpen(false);
+      return;
     }
+
+    setMobileKeyboardEnabled(!getDesktopKeyboardOnMobile());
   }, [open]);
+
+  useEffect(() => {
+    if (typeof window === "undefined") return undefined;
+
+    const handlePreferenceChange = () => {
+      setMobileKeyboardEnabled(!getDesktopKeyboardOnMobile());
+    };
+
+    window.addEventListener(
+      DESKTOP_KEYBOARD_ON_MOBILE_EVENT,
+      handlePreferenceChange
+    );
+    window.addEventListener("storage", handlePreferenceChange);
+
+    return () => {
+      window.removeEventListener(
+        DESKTOP_KEYBOARD_ON_MOBILE_EVENT,
+        handlePreferenceChange
+      );
+      window.removeEventListener("storage", handlePreferenceChange);
+    };
+  }, []);
 
   const calculatePasswordStrength = (password) => {
     if (!password || password.length < PASSWORD_POLICY.minLength) return 0;

--- a/src/components/ui/AccountSettingsDialog.jsx
+++ b/src/components/ui/AccountSettingsDialog.jsx
@@ -29,6 +29,12 @@ import {
 const DESKTOP_KEYBOARD_ON_MOBILE_KEY = "logicapp_desktop_keyboard_on_mobile";
 const DESKTOP_KEYBOARD_ON_MOBILE_EVENT =
   "logicapp_desktop_keyboard_on_mobile_change";
+const TEXT_SIZE_CHOICES = [
+  { value: "smaller", label: "smaller" },
+  { value: "default", label: "default" },
+  { value: "larger", label: "larger" },
+  { value: "largest", label: "largest" },
+];
 
 const getDesktopKeyboardOnMobile = () => {
   if (typeof window === "undefined") return false;
@@ -542,11 +548,11 @@ export default function AccountSettingsDialog({
 
             <Box>
               <Typography variant="h6" sx={{ mb: 1 }}>
-                Display and Text Size
+                Accessibility
               </Typography>
-                <Typography variant="body1" sx={{ fontWeight: 500 }}>
-                  Text Size
-                </Typography>
+              <Typography variant="body1" sx={{ fontWeight: 500 }}>
+                Magnify Text
+              </Typography>
               <Typography
                 variant="body2"
                 color="text.secondary"
@@ -563,35 +569,17 @@ export default function AccountSettingsDialog({
                   flexWrap: "wrap",
                 }}
               >
-                <ButtonGroup variant="outlined" aria-label="text size controls">
-                  <Button
-                    onClick={() => onTextSizeChange?.("smaller")}
-                    variant={textSize === "smaller" ? "contained" : "outlined"}
-                    sx={{ textTransform: "none" }}
-                  >
-                    smaller
-                  </Button>
-                  <Button
-                    onClick={() => onTextSizeChange?.("default")}
-                    variant={textSize === "default" ? "contained" : "outlined"}
-                    sx={{ textTransform: "none" }}
-                  >
-                    default
-                  </Button>
-                  <Button
-                    onClick={() => onTextSizeChange?.("larger")}
-                    variant={textSize === "larger" ? "contained" : "outlined"}
-                    sx={{ textTransform: "none" }}
-                  >
-                    larger
-                  </Button>
-                  <Button
-                    onClick={() => onTextSizeChange?.("largest")}
-                    variant={textSize === "largest" ? "contained" : "outlined"}
-                    sx={{ textTransform: "none" }}
-                  >
-                    largest
-                  </Button>
+                <ButtonGroup variant="outlined" aria-label="magnify text controls">
+                  {TEXT_SIZE_CHOICES.map((choice) => (
+                    <Button
+                      key={choice.value}
+                      onClick={() => onTextSizeChange?.(choice.value)}
+                      variant={textSize === choice.value ? "contained" : "outlined"}
+                      sx={{ textTransform: "none" }}
+                    >
+                      {choice.label}
+                    </Button>
+                  ))}
                 </ButtonGroup>
               </Box>
             </Box>
@@ -614,7 +602,7 @@ export default function AccountSettingsDialog({
                     color="primary"
                   />
                 }
-                label="Mobile logic keyboard"
+                label="Show the touch friendly logic keyboard on mobile devices"
               />
             </Box>
 

--- a/src/components/ui/AccountSettingsDialog.jsx
+++ b/src/components/ui/AccountSettingsDialog.jsx
@@ -8,9 +8,11 @@ import {
   DialogContent,
   DialogTitle,
   Divider,
+  FormControlLabel,
   IconButton,
   InputAdornment,
   Stack,
+  Switch,
   TextField,
   Typography,
 } from "@mui/material";
@@ -22,6 +24,35 @@ import {
   PASSWORD_POLICY_MESSAGE,
   isStrongPassword,
 } from "../../utils/passwords.js";
+
+const DESKTOP_KEYBOARD_ON_MOBILE_KEY = "logicapp_desktop_keyboard_on_mobile";
+const DESKTOP_KEYBOARD_ON_MOBILE_EVENT =
+  "logicapp_desktop_keyboard_on_mobile_change";
+
+const getDesktopKeyboardOnMobile = () => {
+  if (typeof window === "undefined") return false;
+
+  try {
+    return window.localStorage.getItem(DESKTOP_KEYBOARD_ON_MOBILE_KEY) === "true";
+  } catch {
+    return false;
+  }
+};
+
+const setDesktopKeyboardOnMobilePreference = (enabled) => {
+  if (typeof window === "undefined") return;
+
+  try {
+    window.localStorage.setItem(
+      DESKTOP_KEYBOARD_ON_MOBILE_KEY,
+      String(enabled)
+    );
+  } catch {
+    // ignore storage failures
+  }
+
+  window.dispatchEvent(new Event(DESKTOP_KEYBOARD_ON_MOBILE_EVENT));
+};
 
 const getPasswordCriteriaErrors = (password) => {
   const criteriaErrors = [];
@@ -69,6 +100,9 @@ const getErrorMessage = (error) => {
 
 export default function AccountSettingsDialog({ open, onClose }) {
   const { user } = useAuthState();
+  const [mobileKeyboardEnabled, setMobileKeyboardEnabled] = useState(
+    () => !getDesktopKeyboardOnMobile()
+  );
 
   const [currentPassword, setCurrentPassword] = useState("");
   const [newPassword, setNewPassword] = useState("");
@@ -471,6 +505,28 @@ export default function AccountSettingsDialog({ open, onClose }) {
                   </Box>
                 </Box>
               </Stack>
+            </Box>
+
+            <Divider sx={{ my: 1 }} />
+
+            <Box>
+              <Typography variant="h6" sx={{ mb: 1 }}>
+                Mobile Keyboard
+              </Typography>
+              <FormControlLabel
+                control={
+                  <Switch
+                    checked={mobileKeyboardEnabled}
+                    onChange={(event) => {
+                      const enabled = event.target.checked;
+                      setMobileKeyboardEnabled(enabled);
+                      setDesktopKeyboardOnMobilePreference(!enabled);
+                    }}
+                    color="primary"
+                  />
+                }
+                label="Mobile logic keyboard"
+              />
             </Box>
 
             <Divider sx={{ my: 1 }} />

--- a/src/components/ui/LogicKeyboard/MobileLogicInput.jsx
+++ b/src/components/ui/LogicKeyboard/MobileLogicInput.jsx
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { createPortal } from 'react-dom'
-import { Box, Button, Stack } from '@mui/material'
+import { Box, Button, Stack, TextField } from '@mui/material'
 import { alpha } from '@mui/material/styles'
 import { useTheme, useMediaQuery } from '@mui/material'
 import LogicInput from './LogicInput.jsx'
@@ -8,6 +8,18 @@ import SymbolButtonRow, { symbolRowButtonSx } from '../logicpenguin/SymbolButton
 import getSyntax from '../../../lib/logicpenguin/symbolic/libsyntax.js'
 
 const DEFAULT_LETTERS = ['P', 'Q', 'R', 'S', 'T']
+const DESKTOP_KEYBOARD_ON_MOBILE_KEY = 'logicapp_desktop_keyboard_on_mobile'
+const DESKTOP_KEYBOARD_ON_MOBILE_EVENT = 'logicapp_desktop_keyboard_on_mobile_change'
+
+function getDesktopKeyboardOnMobile() {
+  if (typeof window === 'undefined') return false
+
+  try {
+    return window.localStorage.getItem(DESKTOP_KEYBOARD_ON_MOBILE_KEY) === 'true'
+  } catch {
+    return false
+  }
+}
 
 /** Binary operators get leading and trailing space (matches formula-input.js insOp / logic parsing). */
 function isBinaryOp(symbolcat, op) {
@@ -58,11 +70,13 @@ export default function MobileLogicInput({
 }) {
   const theme = useTheme()
   const isPhone = useMediaQuery(theme.breakpoints.down('sm'))
+  const [desktopKeyboardOnMobile, setDesktopKeyboardOnMobile] = useState(getDesktopKeyboardOnMobile)
 
   const [cursorPosition, setCursorPosition] = useState(0)
   const [keyboardFocused, setKeyboardFocused] = useState(false)
   const [isClosing, setIsClosing] = useState(false)
   const [slideIn, setSlideIn] = useState(false)
+  const desktopInputRef = useRef(null)
 
   const onChangeRef = useRef(onChange)
   const setCursorRef = useRef(setCursorPosition)
@@ -126,7 +140,7 @@ export default function MobileLogicInput({
   facade.symbolcat = symbolcat
 
   useEffect(() => {
-    if (!inputRef) return
+    if (!inputRef || (isPhone && desktopKeyboardOnMobile)) return
     if (typeof inputRef === 'function') {
       inputRef(facade)
       return () => inputRef(null)
@@ -135,7 +149,21 @@ export default function MobileLogicInput({
     return () => {
       inputRef.current = null
     }
-  }, [facade, inputRef])
+  }, [desktopKeyboardOnMobile, facade, inputRef, isPhone])
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return undefined
+
+    const handlePreferenceChange = () => {
+      setDesktopKeyboardOnMobile(getDesktopKeyboardOnMobile())
+    }
+
+    window.addEventListener(DESKTOP_KEYBOARD_ON_MOBILE_EVENT, handlePreferenceChange)
+    return () => {
+      window.removeEventListener(DESKTOP_KEYBOARD_ON_MOBILE_EVENT, handlePreferenceChange)
+    }
+  }, [])
+
   const handleFocus = useCallback(() => {
     setKeyboardFocused(true)
     onFocus?.()
@@ -215,6 +243,41 @@ export default function MobileLogicInput({
 
   if (!isPhone) {
     return children ?? null
+  }
+
+  if (desktopKeyboardOnMobile) {
+    const setDesktopInputRef = (node) => {
+      desktopInputRef.current = node
+      if (typeof inputRef === 'function') {
+        inputRef(node)
+      } else if (inputRef) {
+        inputRef.current = node
+      }
+    }
+
+    return children ?? (
+      <TextField
+        fullWidth
+        value={value ?? ''}
+        onChange={(event) => onChange?.(event.target.value)}
+        onFocus={onFocus}
+        onBlur={onBlur}
+        disabled={disabled}
+        placeholder={placeholder}
+        inputRef={setDesktopInputRef}
+        inputProps={{
+          autoComplete: 'off',
+          spellCheck: false,
+          'aria-label': ariaLabel,
+        }}
+        sx={{
+          '& .MuiInputBase-input': {
+            fontFamily: 'monospace',
+            fontSize: '1rem',
+          },
+        }}
+      />
+    )
   }
 
   return (

--- a/src/components/ui/LogicKeyboard/MobileLogicInput.jsx
+++ b/src/components/ui/LogicKeyboard/MobileLogicInput.jsx
@@ -33,8 +33,10 @@ export function useMobileLogicKeyboardEnabled() {
     }
 
     window.addEventListener(DESKTOP_KEYBOARD_ON_MOBILE_EVENT, handlePreferenceChange)
+    window.addEventListener('storage', handlePreferenceChange)
     return () => {
       window.removeEventListener(DESKTOP_KEYBOARD_ON_MOBILE_EVENT, handlePreferenceChange)
+      window.removeEventListener('storage', handlePreferenceChange)
     }
   }, [])
 
@@ -82,6 +84,7 @@ export default function MobileLogicInput({
   symbolizationKey,
   includeQuantifiers = true,
   extraInsertButtons,
+  onEnterKey,
   /** Predicate-logic mode: when all three are provided, show predicates / constants / variables rows instead of a single letter row. */
   predicateLetters,
   constantLetters,
@@ -263,6 +266,7 @@ export default function MobileLogicInput({
         node.autoChange = FormulaInput.autoChange
         node.insertHere = FormulaInput.insertHere
         node.insOp = FormulaInput.insOp
+        node.enterHook = onEnterKey
       }
       if (typeof inputRef === 'function') {
         inputRef(node)
@@ -287,7 +291,17 @@ export default function MobileLogicInput({
             }
           }}
           onFocus={onFocus}
-          onBlur={onBlur}
+          onBlur={(event) => {
+            const input = desktopInputRef.current
+            if (input?.inputfix) {
+              const normalizedValue = input.inputfix(input.value ?? '')
+              if (normalizedValue !== input.value) {
+                input.value = normalizedValue
+                onChange?.(normalizedValue)
+              }
+            }
+            onBlur?.(event)
+          }}
           disabled={disabled}
           placeholder={placeholder}
           inputRef={setDesktopInputRef}

--- a/src/components/ui/LogicKeyboard/MobileLogicInput.jsx
+++ b/src/components/ui/LogicKeyboard/MobileLogicInput.jsx
@@ -21,6 +21,25 @@ function getDesktopKeyboardOnMobile() {
   }
 }
 
+export function useMobileLogicKeyboardEnabled() {
+  const [enabled, setEnabled] = useState(() => !getDesktopKeyboardOnMobile())
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return undefined
+
+    const handlePreferenceChange = () => {
+      setEnabled(!getDesktopKeyboardOnMobile())
+    }
+
+    window.addEventListener(DESKTOP_KEYBOARD_ON_MOBILE_EVENT, handlePreferenceChange)
+    return () => {
+      window.removeEventListener(DESKTOP_KEYBOARD_ON_MOBILE_EVENT, handlePreferenceChange)
+    }
+  }, [])
+
+  return enabled
+}
+
 /** Binary operators get leading and trailing space (matches formula-input.js insOp / logic parsing). */
 function isBinaryOp(symbolcat, op) {
   return symbolcat && typeof symbolcat[op] === 'number' && symbolcat[op] >= 2
@@ -70,7 +89,7 @@ export default function MobileLogicInput({
 }) {
   const theme = useTheme()
   const isPhone = useMediaQuery(theme.breakpoints.down('sm'))
-  const [desktopKeyboardOnMobile, setDesktopKeyboardOnMobile] = useState(getDesktopKeyboardOnMobile)
+  const mobileLogicKeyboardEnabled = useMobileLogicKeyboardEnabled()
 
   const [cursorPosition, setCursorPosition] = useState(0)
   const [keyboardFocused, setKeyboardFocused] = useState(false)
@@ -140,7 +159,7 @@ export default function MobileLogicInput({
   facade.symbolcat = symbolcat
 
   useEffect(() => {
-    if (!inputRef || (isPhone && desktopKeyboardOnMobile)) return
+    if (!inputRef) return
     if (typeof inputRef === 'function') {
       inputRef(facade)
       return () => inputRef(null)
@@ -149,20 +168,7 @@ export default function MobileLogicInput({
     return () => {
       inputRef.current = null
     }
-  }, [desktopKeyboardOnMobile, facade, inputRef, isPhone])
-
-  useEffect(() => {
-    if (typeof window === 'undefined') return undefined
-
-    const handlePreferenceChange = () => {
-      setDesktopKeyboardOnMobile(getDesktopKeyboardOnMobile())
-    }
-
-    window.addEventListener(DESKTOP_KEYBOARD_ON_MOBILE_EVENT, handlePreferenceChange)
-    return () => {
-      window.removeEventListener(DESKTOP_KEYBOARD_ON_MOBILE_EVENT, handlePreferenceChange)
-    }
-  }, [])
+  }, [facade, inputRef])
 
   const handleFocus = useCallback(() => {
     setKeyboardFocused(true)
@@ -245,7 +251,7 @@ export default function MobileLogicInput({
     return children ?? null
   }
 
-  if (desktopKeyboardOnMobile) {
+  if (!mobileLogicKeyboardEnabled) {
     const setDesktopInputRef = (node) => {
       desktopInputRef.current = node
       if (typeof inputRef === 'function') {
@@ -255,7 +261,7 @@ export default function MobileLogicInput({
       }
     }
 
-    return children ?? (
+    return (
       <TextField
         fullWidth
         value={value ?? ''}

--- a/src/components/ui/LogicKeyboard/MobileLogicInput.jsx
+++ b/src/components/ui/LogicKeyboard/MobileLogicInput.jsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
-import { createPortal } from 'react-dom'
+import { createPortal, flushSync } from 'react-dom'
 import { Box, Button, Stack, TextField } from '@mui/material'
 import { alpha } from '@mui/material/styles'
 import { useTheme, useMediaQuery } from '@mui/material'
@@ -256,6 +256,11 @@ export default function MobileLogicInput({
   }
 
   if (!mobileLogicKeyboardEnabled) {
+    const syncDesktopValue = (nextValue) => {
+      valueRef.current = nextValue
+      onChangeRef.current?.(nextValue)
+    }
+
     const setDesktopInputRef = (node) => {
       desktopInputRef.current = node
       if (node) {
@@ -266,7 +271,10 @@ export default function MobileLogicInput({
         node.autoChange = FormulaInput.autoChange
         node.insertHere = FormulaInput.insertHere
         node.insOp = FormulaInput.insOp
-        node.enterHook = onEnterKey
+        node.enterHook = (event) => {
+          flushSync(() => syncDesktopValue(node.value ?? ''))
+          onEnterKey?.(event)
+        }
       }
       if (typeof inputRef === 'function') {
         inputRef(node)
@@ -284,10 +292,10 @@ export default function MobileLogicInput({
           onKeyDown={(event) => {
             const input = desktopInputRef.current
             if (!input) return
-            const previousValue = input.value
             FormulaInput.keydown.call(input, event)
-            if (input.value !== previousValue) {
-              onChange?.(input.value)
+            const nextValue = input.value ?? ''
+            if (nextValue !== valueRef.current) {
+              syncDesktopValue(nextValue)
             }
           }}
           onFocus={onFocus}
@@ -297,7 +305,7 @@ export default function MobileLogicInput({
               const normalizedValue = input.inputfix(input.value ?? '')
               if (normalizedValue !== input.value) {
                 input.value = normalizedValue
-                onChange?.(normalizedValue)
+                syncDesktopValue(normalizedValue)
               }
             }
             onBlur?.(event)

--- a/src/components/ui/LogicKeyboard/MobileLogicInput.jsx
+++ b/src/components/ui/LogicKeyboard/MobileLogicInput.jsx
@@ -3,6 +3,7 @@ import { createPortal } from 'react-dom'
 import { Box, Button, Stack, TextField } from '@mui/material'
 import { alpha } from '@mui/material/styles'
 import { useTheme, useMediaQuery } from '@mui/material'
+import FormulaInput from '../logicpenguin/formula-input.js'
 import LogicInput from './LogicInput.jsx'
 import SymbolButtonRow, { symbolRowButtonSx } from '../logicpenguin/SymbolButtonRow.jsx'
 import getSyntax from '../../../lib/logicpenguin/symbolic/libsyntax.js'
@@ -254,6 +255,15 @@ export default function MobileLogicInput({
   if (!mobileLogicKeyboardEnabled) {
     const setDesktopInputRef = (node) => {
       desktopInputRef.current = node
+      if (node) {
+        node.syntax = syntax
+        node.symbols = symbols
+        node.symbolcat = symbolcat
+        node.inputfix = syntax?.inputfix
+        node.autoChange = FormulaInput.autoChange
+        node.insertHere = FormulaInput.insertHere
+        node.insOp = FormulaInput.insOp
+      }
       if (typeof inputRef === 'function') {
         inputRef(node)
       } else if (inputRef) {
@@ -262,27 +272,47 @@ export default function MobileLogicInput({
     }
 
     return (
-      <TextField
-        fullWidth
-        value={value ?? ''}
-        onChange={(event) => onChange?.(event.target.value)}
-        onFocus={onFocus}
-        onBlur={onBlur}
-        disabled={disabled}
-        placeholder={placeholder}
-        inputRef={setDesktopInputRef}
-        inputProps={{
-          autoComplete: 'off',
-          spellCheck: false,
-          'aria-label': ariaLabel,
-        }}
-        sx={{
-          '& .MuiInputBase-input': {
-            fontFamily: 'monospace',
-            fontSize: '1rem',
-          },
-        }}
-      />
+      <>
+        <TextField
+          fullWidth
+          value={value ?? ''}
+          onChange={(event) => onChange?.(event.target.value)}
+          onKeyDown={(event) => {
+            const input = desktopInputRef.current
+            if (!input) return
+            const previousValue = input.value
+            FormulaInput.keydown.call(input, event)
+            if (input.value !== previousValue) {
+              onChange?.(input.value)
+            }
+          }}
+          onFocus={onFocus}
+          onBlur={onBlur}
+          disabled={disabled}
+          placeholder={placeholder}
+          inputRef={setDesktopInputRef}
+          inputProps={{
+            autoComplete: 'off',
+            spellCheck: false,
+            'aria-label': ariaLabel,
+          }}
+          sx={{
+            '& .MuiInputBase-input': {
+              fontFamily: 'monospace',
+              fontSize: '1rem',
+            },
+          }}
+        />
+        <Box sx={{ mt: 1 }}>
+          <SymbolButtonRow
+            inputRef={desktopInputRef}
+            onValueChange={onChange}
+            disabled={disabled}
+            includeQuantifiers={includeQuantifiers}
+            extraInsertButtons={extraInsertButtons}
+          />
+        </Box>
+      </>
     )
   }
 

--- a/src/components/ui/LogicKeyboard/index.js
+++ b/src/components/ui/LogicKeyboard/index.js
@@ -1,3 +1,4 @@
 export { default as LogicInput } from './LogicInput.jsx'
 export { insertAtCursor, backspaceAtCursor } from './LogicInput.jsx'
 export { default as MobileLogicInput } from './MobileLogicInput.jsx'
+export { useMobileLogicKeyboardEnabled } from './MobileLogicInput.jsx'

--- a/src/components/ui/PromptText.jsx
+++ b/src/components/ui/PromptText.jsx
@@ -1,7 +1,7 @@
 import RichText from './RichText.jsx'
 
 const promptSx = {
-  fontSize: '15px',
+  fontSize: '1.171875rem',
   lineHeight: 2,
   fontWeight: 400,
   color: 'text.primary',

--- a/src/lib/logicpenguin/stylesheets/derivation-hurley.css
+++ b/src/lib/logicpenguin/stylesheets/derivation-hurley.css
@@ -16,7 +16,7 @@
     }
     
     .logicpenguin derivation-hurley .derivationline input.formulainput {
-        font-size: 14px !important;
+        font-size: 1.09375rem !important;
         min-width: 0 !important;
         padding: 0 !important;
         padding-inline: 0.5em !important;
@@ -26,7 +26,7 @@
     }
     
     .logicpenguin derivation-hurley .derivationline input.justification {
-        font-size: 14px !important;
+        font-size: 1.09375rem !important;
         width: 3.5em !important;
         min-width: 3.5em !important;
         max-width: 3.5em !important;
@@ -40,11 +40,11 @@
     .logicpenguin derivation-hurley .derivationcore {
         width: 100% !important;
         max-width: 100% !important;
-        font-size: 14px !important;
+        font-size: 1.09375rem !important;
     }
-    
+
     .logicpenguin derivation-hurley .derivationline .derivationlinenumber {
-        font-size: 14px !important;
+        font-size: 1.09375rem !important;
     }
     
     .logicpenguin derivation-hurley .innersubderiv {
@@ -118,14 +118,14 @@
     display: grid;
     grid-template-columns: 2fr 1fr;
     align-items: center;
-    gap: 12px;
+    gap: 0.9375rem;
 }
 
 .logicpenguin derivation-hurley .derivationline input.formulainput,
 .logicpenguin derivation-hurley .derivationline input.justification {
-    padding: 10px 12px;
+    padding: 0.78125rem 0.9375rem;
     line-height: 1.4;
-    height: 44px;
+    height: 3.4375rem;
 }
 
 .logicpenguin derivation-hurley .derivationline.derivationshowline .bottombar {

--- a/src/pages/Worksheet.jsx
+++ b/src/pages/Worksheet.jsx
@@ -1252,7 +1252,12 @@ function RealWorksheetContent() {
   }
 
   return (
-    <Box sx={{ '& .logicpenguin': { fontSize: '16px' } }}>
+    <Box
+      sx={{
+        // keep the old baseline and let root scaling work
+        '& .logicpenguin': { fontSize: '1.25rem' },
+      }}
+    >
       <WorksheetLayout
         subtitle={currentWorksheet.title || "Predicate Logic: Natural Deduction"}
         onBackToLMS={() => navigate(backTarget)}


### PR DESCRIPTION
## 🔗 Linked Issue

Closes #26 

## 📝 Description

New accessibility controls in account settings:

- mobile logic keyboard toggle that lets users disable the custom mobile keyboard unreadable for screen readers
- magnify text setting that lets users change text size app-wide with presets

## 🚀 Type of Change

- [ ] 🐛 Bug fix
- [x] ✨ New feature
- [ ] 🛠️ Refactor / Chore (Code cleanup, dependency update, etc.)

## 🧪 How to Test

1. Pull down this branch and run `npm run dev -- --host`
2. Open the app on a mobile device
3. Open account settings and turn off `mobile logic keyboard`
4. Navigate to a derivation problem
5. Start a new derivation line
6. Confirm the custom mobile keyboard does not appear
7. Confirm the keyboard shortcuts are still normalized in the fallback input
8. Confirm the row of symbols is visible and functional in derivations
9. Navigate to a symbolic translation problem
10. Confirm the custom mobile keyboard does not appear there either
11. Confirm the normal text input still shows the row of symbols and that the shortcuts are normalized
12. Go back to account settings and turn `mobile logic keyboard` back on
13. Return to the same derivation and translation questions and confirm the custom mobile keyboard appears again
14. Re-open account settings
15. In accessibility, confirm `magnify text` shows `smaller` `default` `larger` and `largest`
16. Switch between each magnify text option and confirm text updates across the app

## ✅ Pre-Merge Checklist

- [x] I have performed a self-review of my own code.
- [x] I have removed all temporary `console.log`s and debuggers.
- [x] I have successfully rebased / resolved any merge conflicts with `main`.
- [x] UI looks good on both desktop and mobile viewports.
