### PR TITLE
Add quantified variables to mobile keyboard

### DIFF
--- a/src/components/problems/derivation/DerivationTable.jsx
+++ b/src/components/problems/derivation/DerivationTable.jsx
@@ -136,10 +136,10 @@ function getQuantifierInsertButtonsFromFormulaText(formulaText) {
   const seen = new Set()
   const buttons = []
 
-  for (const [, insert] of String(formulaText ?? '').matchAll(/(\(?[∀∃][y-z]\)?\[?)/g)) {
-    if (seen.has(insert)) continue
-    seen.add(insert)
-    buttons.push({ insert })
+  for (const [, variable] of String(formulaText ?? '').matchAll(/[∀∃]([y-z])/g)) {
+    if (seen.has(variable)) continue
+    seen.add(variable)
+    buttons.push({ insert: `(∀${variable})` }, { insert: `(∃${variable})` })
   }
 
   return buttons

--- a/src/components/problems/derivation/DerivationTable.jsx
+++ b/src/components/problems/derivation/DerivationTable.jsx
@@ -132,6 +132,19 @@ function getConstantLettersFromFormulasAndKey(formulaText, symbolizationKey) {
 
 const PREDICATE_VARIABLES = ['x', 'y', 'z']
 
+function getQuantifierInsertButtonsFromFormulaText(formulaText) {
+  const seen = new Set()
+  const buttons = []
+
+  for (const [, insert] of String(formulaText ?? '').matchAll(/(\(?[∀∃][y-z]\)?\[?)/g)) {
+    if (seen.has(insert)) continue
+    seen.add(insert)
+    buttons.push({ insert })
+  }
+
+  return buttons
+}
+
 function isPredicateLogicKey(symbolizationKey) {
   if (!Array.isArray(symbolizationKey) || symbolizationKey.length === 0) return false
   return symbolizationKey.some((line) => {
@@ -538,6 +551,7 @@ export default function DerivationTable({
         predicateLetters,
         constantLetters,
         variableLetters,
+        extraInsertButtons: getQuantifierInsertButtonsFromFormulaText(formulaText),
       }
     }
 
@@ -1624,6 +1638,7 @@ export default function DerivationTable({
                         setStoredSelection(idx, Math.max(0, Math.min(safePosition, maxPosition)))
                       }}
                       includeQuantifiers={derivationKeyboardConfig.isPredicateMode}
+                      extraInsertButtons={derivationKeyboardConfig.isPredicateMode ? derivationKeyboardConfig.extraInsertButtons : undefined}
                       predicateLetters={derivationKeyboardConfig.isPredicateMode ? derivationKeyboardConfig.predicateLetters : undefined}
                       constantLetters={derivationKeyboardConfig.isPredicateMode ? derivationKeyboardConfig.constantLetters : undefined}
                       variableLetters={derivationKeyboardConfig.isPredicateMode ? derivationKeyboardConfig.variableLetters : undefined}


### PR DESCRIPTION
## 📝 Description

Adds nested, quantified y and z variables in the premises or conclusion of relational predicate derivations to the mobile keyboard without changing propositional keyboard behavior.