### PR TITLE
dont reparse normalized aip target during ip validation

### DIFF
--- a/src/lib/logicpenguin/checkers/derivation-check.js
+++ b/src/lib/logicpenguin/checkers/derivation-check.js
@@ -720,10 +720,7 @@ export default class DerivationCheck {
         const assumptionNormal = assumptionFormula
             ? assumptionFormula.wrapifneeded()
             : (assumptionLine.formulaNormal ?? '').trim();
-        const expectedFormula = assumptionNormal
-            ? this.Formula.from(notSym + assumptionNormal)
-            : null;
-        const expected = expectedFormula?.normal ?? (notSym + assumptionNormal);
+        const expected = notSym + assumptionNormal;
         if (line.formulaNormal.trim() !== expected) {
             this.adderror(line.n, "rule", "high",
                 "IP conclusion must be the negation of the AIP assumption.");

--- a/src/lib/logicpenguin/symbolic/libsyntax.js
+++ b/src/lib/logicpenguin/symbolic/libsyntax.js
@@ -124,7 +124,7 @@ function inputfix(s) {
 function stripmatching(s) {
     if (s.length < 2) { return s; }
 
-    const qMatch = s.match(/^\(?[∃∀][x-z]\)?/);
+    const qMatch = s.match(/^(?:[∃∀][x-z]|\([∃∀][x-z]\)|\([x-z]\))/);
     if (qMatch) { return s;}
     
     const openBrackets = { '(': ')', '[': ']', '{': '}' };


### PR DESCRIPTION
## 📝 Description

Fixes IP validation of an AIP line with a normalized form that contains quantified statements, such as `~[(∃x)Ax ⊃ ~Cbc]`, by making the checker avoid an unnecessary re-parse for IP validation.

## 🚀 Type of Change

- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 🛠️ Refactor / Chore (Code cleanup, dependency update, etc.)