### PR TITLE
allow UI conclusion constants & disallow them for EI

### DIFF
--- a/src/lib/logicpenguin/checkers/derivation-check.js
+++ b/src/lib/logicpenguin/checkers/derivation-check.js
@@ -1765,7 +1765,6 @@ export class formFit {
                 checkpart = currsubderiv?.parts?.[currindex-1]?? false;
             } else {
                 if (currsubderiv?.showline &&
-                    !currsubderiv.showline.isMainConclusion &&
                     currsubderiv.showline != line) {
                     const f = Formula.from(currsubderiv.showline.s);
                     if (f.terms.indexOf(newname) !== -1) {
@@ -1783,7 +1782,7 @@ export class formFit {
             // if a subderiv, again check its showline,
             // which is available
             if (checkpart.parts) {
-                if (checkpart.showline && !checkpart.showline.isMainConclusion) {
+                if (checkpart.showline) {
                     const f = Formula.from(checkpart.showline.s);
                     if (f.terms.indexOf(newname) !== -1) {
                         return false;


### PR DESCRIPTION
## 📝 Description

Updates what constants can and cannot be used with UI and EI in the Hurley system.

- UI can now use constants from the conclusion in addition to constants from previous derivation lines.
- EI cannot use constants from the conclusion as new names.