### PR TITLE
improved accessibility, updated UI, utility updates

### DIFF
--- a/src/components/problems/derivation/DerivationTable.jsx
+++ b/src/components/problems/derivation/DerivationTable.jsx
@@ -32,11 +32,11 @@ import { MobileLogicInput, useMobileLogicKeyboardEnabled } from '../../ui/LogicK
 import checkDerivation from '../../../lib/logicpenguin/checkers/derivation-hurley.js'
 import getHurleyRuleset from '../../../lib/logicpenguin/checkers/rules/hurley-rules.js'
 import getFormulaClass from '../../../lib/logicpenguin/symbolic/formula.js'
-import getSyntax from '../../../lib/logicpenguin/symbolic/libsyntax.js'
+import getSyntax, { resolveNotationName } from '../../../lib/logicpenguin/symbolic/libsyntax.js'
 import { justParse } from '../../ui/logicpenguin/justification-parse.js'
 import { getInsertSymbolLabel } from '../../ui/logicpenguin/LogicSymbol.jsx'
 import { buildPersistedSubmissionState, shouldUseApiValidation, submitApiValidation } from '../../../utils/submissionRuntime.js'
-import { getOpenAssumptionDepths, isResolvedConclusionLine } from './derivationUtils.js'
+import { formatQuantifier, getDerivationSymbolButtons, getOpenAssumptionDepths, isResolvedConclusionLine } from './derivationUtils.js'
 
 /** Compare formula strings by canonical form so ∃x(~Hx) and ∃x~Hx count equal */
 function formulasEqualNormally(a, b, normalizeForFallback) {
@@ -132,14 +132,20 @@ function getConstantLettersFromFormulasAndKey(formulaText, symbolizationKey) {
 
 const PREDICATE_VARIABLES = ['x', 'y', 'z']
 
-function getQuantifierInsertButtonsFromFormulaText(formulaText) {
+function getQuantifierInsertButtonsFromFormulaText(formulaText, syntax) {
   const seen = new Set()
   const buttons = []
+  const forall = syntax?.symbols?.FORALL || '∀'
+  const exists = syntax?.symbols?.EXISTS || '∃'
+  const match = String(formulaText ?? '').matchAll(new RegExp(`[${forall}${exists}]([y-z])`, 'g'))
 
-  for (const [, variable] of String(formulaText ?? '').matchAll(/[∀∃]([y-z])/g)) {
+  for (const [, variable] of match) {
     if (seen.has(variable)) continue
     seen.add(variable)
-    buttons.push({ insert: `(∀${variable})` }, { insert: `(∃${variable})` })
+    const forallInsert = formatQuantifier(syntax, 'FORALL', variable)
+    const existsInsert = formatQuantifier(syntax, 'EXISTS', variable)
+    if (forallInsert) buttons.push({ insert: forallInsert })
+    if (existsInsert) buttons.push({ insert: existsInsert })
   }
 
   return buttons
@@ -153,42 +159,34 @@ function isPredicateLogicKey(symbolizationKey) {
   })
 }
 
-const DEFAULT_QUANTIFIER_INSERTS = new Set(['(∀x)', '(∃x)'])
-
-function getQuantifierButtonsFromFormulas(premises, conclusion) {
+function getQuantifierButtonsFromFormulas(premises, conclusion, syntax) {
   const formulas = [...(Array.isArray(premises) ? premises : []), conclusion].filter(Boolean).map(String)
   const text = formulas.join(' ')
-  const seen = new Set(DEFAULT_QUANTIFIER_INSERTS)
+  const forall = syntax?.symbols?.FORALL || '∀'
+  const exists = syntax?.symbols?.EXISTS || '∃'
+  const defaultInserts = new Set([
+    formatQuantifier(syntax, 'FORALL'),
+    formatQuantifier(syntax, 'EXISTS'),
+  ].filter(Boolean))
   const buttons = []
-  const matches = text.match(/\(?[∀∃][x-z]\)?/g)
+  const matches = text.match(new RegExp(`\\(?[${forall}${exists}][x-z]\\)?`, 'g'))
 
   if (!matches) return buttons
 
   for (const rawMatch of matches) {
-    const match = rawMatch.match(/[∀∃][x-z]/)
-    if (!match) continue
-    const insert = `(${match[0]})`
-    if (seen.has(insert)) continue
-    seen.add(insert)
+    const pieces = rawMatch.match(new RegExp(`[${forall}${exists}]([x-z])`))
+    if (!pieces) continue
+    const [, variable] = pieces
+    const op = pieces[0][0] === exists ? 'EXISTS' : 'FORALL'
+    const insert = formatQuantifier(syntax, op, variable)
+    if (!insert || defaultInserts.has(insert)) continue
+    defaultInserts.add(insert)
     buttons.push({ label: insert, insert })
   }
 
   return buttons
 }
 
-const SYMBOL_BUTTONS = [
-  { label: '~', insert: '~' },
-  { label: '•', insert: '•' },
-  { label: '∨', insert: '∨' },
-  { label: '⊃', insert: '⊃' },
-  { label: '≡', insert: '≡' },
-  { label: '(∀x)', insert: '(∀x)' },
-  { label: '(∃x)', insert: '(∃x)' },
-  { label: '(  )', pair: '()' },
-  { label: '[  ]', pair: '[]' },
-]
-// mobile fullscreen only. second row: (∀x) (∃x) ( ) [ ] under ~ • ∨ ⊃
-const SYMBOL_ROW2 = [SYMBOL_BUTTONS[5], SYMBOL_BUTTONS[6], SYMBOL_BUTTONS[7], SYMBOL_BUTTONS[8]]
 const FORCE_UPPER_RULES = new Set(['UI','UG','EI','EG','MP','MT','HS','DS','CD','DN','DM','QN','CP','IP','ACP','AIP'])
 const ALL_DERIVATION_RULES = Object.keys(getHurleyRuleset())
   .filter((r) => r !== 'Pr' && r !== 'Ass')
@@ -490,7 +488,8 @@ export default function DerivationTable({
   const lastFormulaIndexRef = useRef(null)
   const lastEditableIndexRef = useRef(null)
   const cursorPositionsRef = useRef({})
-  const syntax = useMemo(() => getSyntax(), [])
+  const notation = useMemo(() => resolveNotationName(proof), [proof])
+  const syntax = useMemo(() => getSyntax(notation), [notation])
   const premises = useMemo(
     () => (Array.isArray(proof?.premises) ? proof.premises : []),
     [proof?.premises]
@@ -553,9 +552,11 @@ export default function DerivationTable({
     const premises = Array.isArray(proof?.premises) ? proof.premises : []
     const conclusion = proof?.conclusion ?? proof?.conc ?? ''
     const formulaText = [...premises, conclusion].filter(Boolean).map(String).join(' ')
-    const extraQuantifierButtons = getQuantifierButtonsFromFormulas(premises, conclusion)
+    const extraQuantifierButtons = getQuantifierButtonsFromFormulas(premises, conclusion, syntax)
+    const forall = syntax?.symbols?.FORALL || '∀'
+    const exists = syntax?.symbols?.EXISTS || '∃'
 
-    const isPredicate = isPredicateLogicKey(key) || /[∀∃]/.test(formulaText) || /[A-Z][a-z]/.test(formulaText)
+    const isPredicate = isPredicateLogicKey(key) || formulaText.includes(forall) || formulaText.includes(exists) || /[A-Z][a-z]/.test(formulaText)
 
     if (isPredicate) {
       const keyText = key.map((line) => (typeof line === 'string' ? line : String(line ?? ''))).join(' ')
@@ -575,7 +576,7 @@ export default function DerivationTable({
         predicateLetters,
         constantLetters,
         variableLetters,
-        extraInsertButtons: getQuantifierInsertButtonsFromFormulaText(formulaText),
+        extraInsertButtons: getQuantifierInsertButtonsFromFormulaText(formulaText, syntax),
         extraQuantifierButtons,
       }
     }
@@ -587,16 +588,16 @@ export default function DerivationTable({
       symbolizationKey: predicateLetters,
       extraQuantifierButtons,
     }
-  }, [proof])
+  }, [proof, syntax])
+  const connectiveButtons = useMemo(() => getDerivationSymbolButtons(syntax), [syntax])
   const symbolButtons = useMemo(() => {
     const extraQuantifierButtons = derivationKeyboardConfig.extraQuantifierButtons || []
-    if (extraQuantifierButtons.length === 0) return SYMBOL_BUTTONS
-    return [
-      ...SYMBOL_BUTTONS.slice(0, 7),
-      ...extraQuantifierButtons,
-      ...SYMBOL_BUTTONS.slice(7),
-    ]
-  }, [derivationKeyboardConfig.extraQuantifierButtons])
+    if (extraQuantifierButtons.length === 0) return connectiveButtons
+    const pairsStart = connectiveButtons.findIndex((button) => button.pair)
+    const head = pairsStart === -1 ? connectiveButtons : connectiveButtons.slice(0, pairsStart)
+    const tail = pairsStart === -1 ? [] : connectiveButtons.slice(pairsStart)
+    return [...head, ...extraQuantifierButtons, ...tail]
+  }, [connectiveButtons, derivationKeyboardConfig.extraQuantifierButtons])
   const isLineCompleteForCheck = useCallback((line) => {
     if (!line) return false
     const formulaFilled = (line.formula || '').trim().length > 0
@@ -660,11 +661,13 @@ export default function DerivationTable({
 
   const normalizeFormulaForCheck = useMemo(
     () => (value) => {
+      const ops = [syntax?.symbols?.IFF, syntax?.symbols?.IFTHEN, syntax?.symbols?.OR, syntax?.symbols?.AND]
+        .filter(Boolean)
+        .map((op) => op.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'))
+        .join('')
       const fixed = syntax.inputfix(String(value ?? '')).replace(/\s+/g, '')
-      return fixed
-        .replace(/([≡⊃∨•])/g, ' $1 ')
-        .replace(/\s+/g, ' ')
-        .trim()
+      const spaced = ops ? fixed.replace(new RegExp(`([${ops}])`, 'g'), ' $1 ') : fixed
+      return spaced.replace(/\s+/g, ' ').trim()
     },
     [syntax]
   )
@@ -1131,35 +1134,40 @@ export default function DerivationTable({
       setTimeout(() => el.setSelectionRange(nextCursor, nextCursor), 0)
     }
 
+    const symbols = syntax?.symbols || {}
     if (!hasModifier && (key === '&' || key === '^' || key === '.' || key === '*' || key === '•' || key === '·' || key === '∧')) {
-      insertSymbol('•')
+      insertSymbol(symbols.AND || '•')
       return
     }
     if (!hasModifier && (key === 'v' || key === '∨')) {
-      insertSymbol('∨')
+      insertSymbol(symbols.OR || '∨')
       return
     }
     if (!hasModifier && (key === '>' || key === '→' || key === '⇒' || key === '⊃')) {
       const hyphenMatch = value.slice(0, start).match(/-+$/)
       const replaceBefore = hyphenMatch ? hyphenMatch[0].length : 0
-      insertSymbol('⊃', replaceBefore)
+      insertSymbol(symbols.IFTHEN || '⊃', replaceBefore)
       return
     }
     if (!hasModifier && key === '=' && start > 0 && value[start - 1] === '=') {
-      insertSymbol('≡', 1)
+      insertSymbol(symbols.IFF || '≡', 1)
+      return
+    }
+    if (!hasModifier && (key === '~' || key === '¬' || key === '!')) {
+      insertSymbol(symbols.NOT || '~')
       return
     }
     if (!hasModifier && (key === 'l' || key === 'L')) {
       const textWithKey = value.slice(0, start) + key.toLowerCase()
       if (/all$/i.test(textWithKey)) {
-        insertSymbol('∀', 2) // replace only 'al' so ~all → ~∀
+        insertSymbol(symbols.FORALL || '∀', 2) // replace only 'al' so ~all → ~∀
       }
       return
     }
     if (!hasModifier && (key === 'e' || key === 'E')) {
       const textWithKey = value.slice(0, start) + key.toLowerCase()
       if (/some$/i.test(textWithKey)) {
-        insertSymbol('∃', 3) // replace only 'som' so ~some → ~∃
+        insertSymbol(symbols.EXISTS || '∃', 3) // replace only 'som' so ~some → ~∃
       }
     }
   }
@@ -1678,6 +1686,7 @@ export default function DerivationTable({
                       constantLetters={derivationKeyboardConfig.isPredicateMode ? derivationKeyboardConfig.constantLetters : undefined}
                       variableLetters={derivationKeyboardConfig.isPredicateMode ? derivationKeyboardConfig.variableLetters : undefined}
                       symbolizationKey={derivationKeyboardConfig.symbolizationKey}
+                      notation={notation}
                     />
                   ) : (
                   <TextField

--- a/src/components/problems/derivation/DerivationTableRows.jsx
+++ b/src/components/problems/derivation/DerivationTableRows.jsx
@@ -17,6 +17,7 @@ import RemoveIcon from '@mui/icons-material/Remove'
 import { alpha } from '@mui/material/styles'
 import { getInsertSymbolLabel } from '../../ui/logicpenguin/LogicSymbol.jsx'
 import MobileLogicInput from '../../ui/LogicKeyboard/MobileLogicInput.jsx'
+import { resolveNotationName } from '../../../lib/logicpenguin/symbolic/libsyntax.js'
 import {
   applyLinesToJustification,
   applyRuleToJustification,
@@ -69,6 +70,7 @@ export default function DerivationTableRows({
   updateCursorPosition,
   useRuleDropdown,
 }) {
+  const notation = resolveNotationName(proof)
   return (
     <>
       {premises.length === 0 && proof?.conclusion && (
@@ -242,6 +244,7 @@ export default function DerivationTableRows({
                       constantLetters={derivationKeyboardConfig?.isPredicateMode ? derivationKeyboardConfig.constantLetters : undefined}
                       variableLetters={derivationKeyboardConfig?.isPredicateMode ? derivationKeyboardConfig.variableLetters : undefined}
                       symbolizationKey={derivationKeyboardConfig?.symbolizationKey}
+                      notation={notation}
                     />
                   </Box>
                 ) : (

--- a/src/components/problems/derivation/derivationUtils.js
+++ b/src/components/problems/derivation/derivationUtils.js
@@ -1,6 +1,7 @@
 import { alpha } from '@mui/material/styles'
 import getHurleyRuleset from '../../../lib/logicpenguin/checkers/rules/hurley-rules.js'
 import getFormulaClass from '../../../lib/logicpenguin/symbolic/formula.js'
+import getSyntax from '../../../lib/logicpenguin/symbolic/libsyntax.js'
 import { justParse } from '../../ui/logicpenguin/justification-parse.js'
 
 const CONSTANT_POOL = 'abcdefghijklmnopqrstuvw'.split('')
@@ -68,19 +69,33 @@ export function getPropositionalLettersFromFormulas(premises, conclusion) {
   return letters.length > 0 ? letters : null
 }
 
-export const SYMBOL_BUTTONS = [
-  { label: '~', insert: '~' },
-  { label: '•', insert: '•' },
-  { label: '∨', insert: '∨' },
-  { label: '⊃', insert: '⊃' },
-  { label: '≡', insert: '≡' },
-  { label: '(∀x)', insert: '(∀x)' },
-  { label: '(∃x)', insert: '(∃x)' },
-  { label: '(  )', pair: '()' },
-  { label: '[  ]', pair: '[]' },
-]
+export function formatQuantifier(syntax, op, variable = 'x') {
+  const symbol = syntax?.symbols?.[op]
+  if (!symbol) return ''
+  if (typeof syntax.mkquantifier === 'function') {
+    return syntax.mkquantifier(variable, symbol)
+  }
+  return `(${symbol}${variable})`
+}
 
-export const SYMBOL_ROW2 = [SYMBOL_BUTTONS[5], SYMBOL_BUTTONS[6], SYMBOL_BUTTONS[7], SYMBOL_BUTTONS[8]]
+export function getDerivationSymbolButtons(syntax = getSyntax()) {
+  const symbols = syntax?.symbols || {}
+  const forall = formatQuantifier(syntax, 'FORALL')
+  const exists = formatQuantifier(syntax, 'EXISTS')
+  return [
+    { label: symbols.NOT, insert: symbols.NOT },
+    { label: symbols.AND, insert: symbols.AND },
+    { label: symbols.OR, insert: symbols.OR },
+    { label: symbols.IFTHEN, insert: symbols.IFTHEN },
+    { label: symbols.IFF, insert: symbols.IFF },
+    { label: forall, insert: forall },
+    { label: exists, insert: exists },
+    { label: '(  )', pair: '()' },
+    { label: '[  ]', pair: '[]' },
+  ].filter((button) => button.pair || Boolean(button.insert))
+}
+
+export const SYMBOL_BUTTONS = getDerivationSymbolButtons()
 export const FORCE_UPPER_RULES = new Set(['UI', 'UG', 'EI', 'EG', 'MP', 'MT', 'HS', 'DS', 'CD', 'DN', 'DM', 'QN', 'CP', 'IP', 'ACP', 'AIP'])
 export const ALL_DERIVATION_RULES = Object.keys(getHurleyRuleset())
   .filter((rule) => rule !== 'Pr' && rule !== 'Ass')

--- a/src/components/problems/mui/inputs/FormulaField.jsx
+++ b/src/components/problems/mui/inputs/FormulaField.jsx
@@ -16,6 +16,7 @@ const FormulaField = forwardRef(function FormulaField({
   predicateLetters,
   constantLetters,
   variableLetters,
+  notation,
   sx,
 }, ref) {
   const theme = useTheme()
@@ -37,6 +38,7 @@ const FormulaField = forwardRef(function FormulaField({
         predicateLetters={predicateLetters}
         constantLetters={constantLetters}
         variableLetters={variableLetters}
+        notation={notation}
       />
     )
   }

--- a/src/components/problems/mui/inputs/SymbolToolbar.jsx
+++ b/src/components/problems/mui/inputs/SymbolToolbar.jsx
@@ -26,19 +26,27 @@ const BUTTONS = [
 
 const INSERT_LABELS = {
   '~': 'Insert tilde',
+  '¬': 'Insert negation',
   '•': 'Insert dot',
+  '∧': 'Insert conjunction',
   '∨': 'Insert wedge',
   '⊃': 'Insert horseshoe',
+  '→': 'Insert arrow',
   '≡': 'Insert triple bar',
+  '↔': 'Insert biconditional',
   '∀': 'Insert universal quantifier',
   '∃': 'Insert existential quantifier',
   '()': 'Insert parentheses',
   '[]': 'Insert brackets',
 }
 
-const getInsertText = (symbols, { op, quantifier = false, pair = null }) => {
+const getInsertText = (syntax, { op, quantifier = false, pair = null }) => {
   if (pair) return pair
+  const symbols = syntax?.symbols || {}
   const symbol = symbols?.[op] || FALLBACK_SYMBOLS[op] || op
+  if (quantifier && typeof syntax?.mkquantifier === 'function') {
+    return syntax.mkquantifier('x', symbol)
+  }
   return quantifier ? `(${symbol}x)` : symbol
 }
 
@@ -89,11 +97,11 @@ export default function SymbolToolbar({
   onValueChange,
   disabled = false,
   includeQuantifiers = true,
+  notation,
 }) {
   const theme = useTheme()
   const isPhone = useMediaQuery(theme.breakpoints.down('sm'))
-  const syntax = getSyntax()
-  const symbols = syntax?.symbols || {}
+  const syntax = getSyntax(notation)
   const visibleButtons = includeQuantifiers
     ? BUTTONS
     : BUTTONS.filter((button) => !button.quantifier)
@@ -104,7 +112,7 @@ export default function SymbolToolbar({
   return (
     <Stack direction="row" spacing={0.5} flexWrap="wrap" useFlexGap aria-label="Symbol shortcuts">
       {visibleButtons.map(({ op, quantifier, pair }) => {
-        const insertText = getInsertText(symbols, { op, quantifier, pair })
+        const insertText = getInsertText(syntax, { op, quantifier, pair })
         return (
           <Button
             key={op || pair}

--- a/src/components/problems/mui/translation/ComboTranslationDerivation.jsx
+++ b/src/components/problems/mui/translation/ComboTranslationDerivation.jsx
@@ -11,6 +11,7 @@ import ProblemSetButtons from '../frame/ProblemSetButtons.jsx'
 import FormulaInput from '../../../ui/logicpenguin/formula-input.js'
 import SymbolButtonRow from '../../../ui/logicpenguin/SymbolButtonRow.jsx'
 import { MobileLogicInput } from '../../../ui/LogicKeyboard/index.js'
+import { resolveNotationName } from '../../../../lib/logicpenguin/symbolic/libsyntax.js'
 import DerivationTable from '../../derivation/DerivationTable.jsx'
 import getFormulaClass from '../../../../lib/logicpenguin/symbolic/formula.js'
 import { useProblemChecker } from '../../../../hooks/useProblemChecker.js'
@@ -25,7 +26,7 @@ import {
   promptImpliesPredicateLogic,
 } from './symbolizationKeyboard.js'
 
-function FormulaInputField({ value, onValueChange, formulaInputRef }) {
+function FormulaInputField({ value, onValueChange, formulaInputRef, notation }) {
   const theme = useTheme()
   const containerRef = useRef(null)
   const changeHandlerRef = useRef(null)
@@ -33,7 +34,7 @@ function FormulaInputField({ value, onValueChange, formulaInputRef }) {
   useEffect(() => {
     if (!containerRef.current) return
     if (!formulaInputRef.current) {
-      const formulaInput = FormulaInput.getnew({})
+      const formulaInput = FormulaInput.getnew({ notation })
       formulaInputRef.current = formulaInput
       formulaInput.style.width = '100%'
       formulaInput.style.padding = theme.spacing(1.5)
@@ -60,7 +61,7 @@ function FormulaInputField({ value, onValueChange, formulaInputRef }) {
         formulaInputRef.current = null
       }
     }
-  }, [formulaInputRef, theme])
+  }, [formulaInputRef, notation, theme])
 
   useEffect(() => {
     const formulaInput = formulaInputRef.current
@@ -253,6 +254,7 @@ export default function ComboTranslationDerivation({
   const inputRef = useRef(null)
   const [fullScreenOpen, setFullScreenOpen] = useState(false)
   const [fullScreenFocusTarget, setFullScreenFocusTarget] = useState(null)
+  const notation = resolveNotationName(proof)
 
   useEffect(() => {
     if (savedState?.argumentLine !== undefined) {
@@ -456,12 +458,13 @@ export default function ComboTranslationDerivation({
                   onChange={handleArgumentChange}
                   placeholder="e.g. A ⊃ B / A // B"
                   aria-label="Argument line"
-                  includeQuantifiers
+                  includeQuantifiers={Boolean(argumentKeyboardConfig.isPredicateMode)}
                   symbolizationKey={argumentKeyboardConfig.symbolizationKey}
                   extraInsertButtons={[{ insert: '/' }, { insert: '//' }]}
                   predicateLetters={argumentKeyboardConfig.isPredicateMode ? argumentKeyboardConfig.predicateLetters : undefined}
                   constantLetters={argumentKeyboardConfig.isPredicateMode ? argumentKeyboardConfig.constantLetters : undefined}
                   variableLetters={argumentKeyboardConfig.isPredicateMode ? argumentKeyboardConfig.variableLetters : undefined}
+                  notation={notation}
                 />
               ) : (
                 <>
@@ -469,11 +472,15 @@ export default function ComboTranslationDerivation({
                     value={argumentLine}
                     onValueChange={handleArgumentChange}
                     formulaInputRef={inputRef}
+                    notation={notation}
                   />
                   <Box sx={{ mt: 1 }}>
                     <SymbolButtonRow
                       inputRef={inputRef}
                       onValueChange={handleArgumentChange}
+                      includeQuantifiers={Boolean(argumentKeyboardConfig.isPredicateMode)}
+                      extraInsertButtons={[{ insert: '/' }, { insert: '//' }]}
+                      notation={notation}
                     />
                   </Box>
                 </>

--- a/src/components/problems/mui/translation/ComboTranslationTruthTable.jsx
+++ b/src/components/problems/mui/translation/ComboTranslationTruthTable.jsx
@@ -4,7 +4,7 @@ import EditIcon from '@mui/icons-material/Edit'
 import InstructorQuestionEditor from '../../InstructorQuestionEditor.jsx'
 import StatusBanner, { isTerminalStatus } from '../../../ui/StatusBanner.jsx'
 import { useTheme, useMediaQuery } from '@mui/material'
-import getSyntax from '../../../../lib/logicpenguin/symbolic/libsyntax.js'
+import getSyntax, { resolveNotationName } from '../../../../lib/logicpenguin/symbolic/libsyntax.js'
 import ProblemSetButtons from '../frame/ProblemSetButtons.jsx'
 import FormulaInput from '../../../ui/logicpenguin/formula-input.js'
 import SymbolButtonRow from '../../../ui/logicpenguin/SymbolButtonRow.jsx'
@@ -111,7 +111,8 @@ export default function ComboTranslationTruthTable({
   const editorRef = useRef(null)
   const openEdit = () => editorRef.current?.open?.()
   const Formula = useMemo(() => getFormulaClass(), [])
-  const syntax = useMemo(() => getSyntax(), [])
+  const notation = useMemo(() => resolveNotationName(proof), [proof])
+  const syntax = useMemo(() => getSyntax(notation), [notation])
   const snapshot = proof?.comboTranslationTruthTable || proof?.snapshot || {}
   const promptText = snapshot?.prompt || proof?.description || ''
   const symbolizationKey = useMemo(
@@ -127,7 +128,7 @@ export default function ComboTranslationTruthTable({
     if (isPhone) return
     const container = inputContainerRef.current
     if (!container) return
-    const inp = FormulaInput.getnew({})
+    const inp = FormulaInput.getnew({ notation })
     inputRef.current = inp
     Object.assign(inp.style, {
       width: '100%',
@@ -154,7 +155,7 @@ export default function ComboTranslationTruthTable({
       if (inp.parentNode) inp.parentNode.removeChild(inp)
       inputRef.current = null
     }
-  }, [theme, isPhone])
+  }, [theme, isPhone, notation])
 
   useEffect(() => {
     if (isPhone) return
@@ -180,14 +181,11 @@ export default function ComboTranslationTruthTable({
       return { ok: false, reason: '', parsed: null }
     }
     const quantSymbols = [syntax?.symbols?.FORALL, syntax?.symbols?.EXISTS].filter(Boolean)
-    if (quantSymbols.length > 0) {
-      const quantRegex = new RegExp(`[${quantSymbols.join('')}]`)
-      if (quantRegex.test(argumentLine)) {
-        return {
-          ok: false,
-          reason: 'Truth tables do not support quantifiers.',
-          parsed: null,
-        }
+    if (quantSymbols.some((symbol) => argumentLine.includes(symbol))) {
+      return {
+        ok: false,
+        reason: 'Truth tables do not support quantifiers.',
+        parsed: null,
       }
     }
     const parsed = parseArgumentLine(argumentLine)
@@ -201,7 +199,7 @@ export default function ComboTranslationTruthTable({
     } catch {
       return { ok: false, reason: 'Fix the argument line before building the table.', parsed: null }
     }
-  }, [Formula, argumentLine])
+  }, [Formula, argumentLine, syntax])
 
   const tableProof = useMemo(() => {
     if (!parseStatus.ok || !parseStatus.parsed) return null
@@ -318,6 +316,7 @@ export default function ComboTranslationTruthTable({
                   symbolizationKey={symbolizationKey}
                   includeQuantifiers={false}
                   extraInsertButtons={[{ insert: '/' }, { insert: '//' }]}
+                  notation={notation}
                 />
               ) : (
                 <>
@@ -330,6 +329,8 @@ export default function ComboTranslationTruthTable({
                       inputRef={inputRef}
                       onValueChange={handleArgumentChange}
                       includeQuantifiers={false}
+                      extraInsertButtons={[{ insert: '/' }, { insert: '//' }]}
+                      notation={notation}
                     />
                   </Box>
                 </>

--- a/src/components/problems/mui/translation/SymbolicTranslation.jsx
+++ b/src/components/problems/mui/translation/SymbolicTranslation.jsx
@@ -1,5 +1,5 @@
 import { useState, useEffect, useRef, useCallback } from 'react'
-import { Box, Stack, Typography, Alert, Tooltip } from '@mui/material'
+import { Box, Stack, Typography, Tooltip } from '@mui/material'
 import EditIcon from '@mui/icons-material/Edit'
 import InstructorQuestionEditor from '../../InstructorQuestionEditor.jsx'
 import { useTheme, useMediaQuery } from '@mui/material'
@@ -7,6 +7,7 @@ import ProblemSetButtons from '../frame/ProblemSetButtons.jsx'
 import FormulaInput from '../../../ui/logicpenguin/formula-input.js'
 import SymbolButtonRow from '../../../ui/logicpenguin/SymbolButtonRow.jsx'
 import { MobileLogicInput } from '../../../ui/LogicKeyboard/index.js'
+import { resolveNotationName } from '../../../../lib/logicpenguin/symbolic/libsyntax.js'
 import { useProblemChecker } from '../../../../hooks/useProblemChecker.js'
 import SolutionReveal from '../../SolutionReveal.jsx'
 import StatusBanner, { isTerminalStatus } from '../../../ui/StatusBanner.jsx'
@@ -21,7 +22,7 @@ import {
   promptImpliesPredicateLogic,
 } from './symbolizationKeyboard.js'
 
-function FormulaInputField({ value, onValueChange, fieldReadOnly, formulaInputRef, onEnterKey, ariaLabel }) {
+function FormulaInputField({ value, onValueChange, fieldReadOnly, formulaInputRef, onEnterKey, ariaLabel, notation }) {
   const theme = useTheme()
   const containerRef = useRef(null)
   const changeHandlerRef = useRef(null)
@@ -29,7 +30,7 @@ function FormulaInputField({ value, onValueChange, fieldReadOnly, formulaInputRe
   useEffect(() => {
     if (!containerRef.current) return
     if (!formulaInputRef.current) {
-      const formulaInput = FormulaInput.getnew({})
+      const formulaInput = FormulaInput.getnew({ notation })
       formulaInputRef.current = formulaInput
       formulaInput.style.width = '100%'
       formulaInput.style.padding = theme.spacing(1.5)
@@ -57,7 +58,7 @@ function FormulaInputField({ value, onValueChange, fieldReadOnly, formulaInputRe
         formulaInputRef.current = null
       }
     }
-  }, [ariaLabel, formulaInputRef, theme])
+  }, [ariaLabel, formulaInputRef, notation, theme])
 
   useEffect(() => {
     if (!formulaInputRef.current) return
@@ -174,6 +175,7 @@ export default function SymbolicTranslation({
             : []))
     : []
   const variableLetters = isPredicate ? ST_PREDICATE_VARIABLES : []
+  const notation = resolveNotationName(proof) || resolveNotationName(problem)
 
   const scheduleStateSave = useCallback((nextValue) => {
     if (!onStateChange) return
@@ -301,6 +303,7 @@ export default function SymbolicTranslation({
                   predicateLetters={isPredicate ? predicateLetters : undefined}
                   constantLetters={isPredicate ? constantLetters : undefined}
                   variableLetters={isPredicate ? variableLetters : undefined}
+                  notation={notation}
                 />
               ) : (
                 <>
@@ -315,12 +318,14 @@ export default function SymbolicTranslation({
                     formulaInputRef={formulaInputRef}
                     onEnterKey={!readOnly && !hideActions ? handleCheck : undefined}
                     ariaLabel="Your translation"
+                    notation={notation}
                   />
                   <Box sx={{ mt: 1 }}>
                     <SymbolButtonRow
                       inputRef={formulaInputRef}
                       disabled={readOnly}
                       includeQuantifiers={isPredicate}
+                      notation={notation}
                       onValueChange={(value) => {
                         if (readOnly) return
                         setInputValue(value)
@@ -340,6 +345,7 @@ export default function SymbolicTranslation({
                   fieldReadOnly
                   formulaInputRef={solutionInputRef}
                   ariaLabel="Correct translation"
+                  notation={notation}
                 />
               </SolutionReveal>
             )}

--- a/src/components/ui/LogicKeyboard/LogicInput.jsx
+++ b/src/components/ui/LogicKeyboard/LogicInput.jsx
@@ -1,5 +1,6 @@
 import { useCallback, useState, useEffect, useRef } from 'react'
 import { Box } from '@mui/material'
+import { alpha } from '@mui/material/styles'
 
 const visuallyHiddenSx = {
   position: 'absolute',
@@ -77,13 +78,16 @@ export default function LogicInput({
     (e) => {
       if (disabled) return
       const target = e.target
-      const index = target.getAttribute('data-char-index')
-      if (index !== null) {
+      const index = target.getAttribute?.('data-char-index')
+      if (index !== null && index !== undefined) {
         const i = parseInt(index, 10)
-        if (Number.isFinite(i)) setCursor(i + 1)
-      } else {
-        setCursor(len)
+        if (!Number.isFinite(i)) return
+        const rect = target.getBoundingClientRect()
+        setCursor(e.clientX > rect.left + rect.width / 2 ? i + 1 : i)
+        return
       }
+      const rect = e.currentTarget.getBoundingClientRect()
+      setCursor(e.clientX < rect.left + rect.width / 2 ? 0 : len)
     },
     [disabled, setCursor, len]
   )
@@ -91,9 +95,8 @@ export default function LogicInput({
   const handleFocus = useCallback(() => {
     if (disabled) return
     setIsFocused(true)
-    if (value.length > 0 && clampedCursor === 0) setCursor(value.length)
     onFocus?.()
-  }, [disabled, onFocus, value.length, clampedCursor, setCursor])
+  }, [disabled, onFocus])
 
   const handleBlur = useCallback(() => {
     setIsFocused(false)
@@ -122,6 +125,16 @@ export default function LogicInput({
         if (clampedCursor < len) setCursor(clampedCursor + 1)
         return
       }
+      if (e.key === 'Home') {
+        e.preventDefault()
+        setCursor(0)
+        return
+      }
+      if (e.key === 'End') {
+        e.preventDefault()
+        setCursor(len)
+        return
+      }
       if (e.key.length === 1 && !e.ctrlKey && !e.metaKey && !e.altKey) {
         e.preventDefault()
         const next = value.slice(0, clampedCursor) + e.key + value.slice(clampedCursor)
@@ -139,6 +152,7 @@ export default function LogicInput({
       aria-multiline={false}
       aria-placeholder={placeholder || undefined}
       aria-readonly={disabled ? 'true' : undefined}
+      aria-disabled={disabled ? 'true' : undefined}
       tabIndex={disabled ? undefined : 0}
       onClick={handleContainerClick}
       onFocus={handleFocus}
@@ -150,7 +164,9 @@ export default function LogicInput({
         py: 1,
         border: '1px solid',
         borderColor: isFocused ? 'primary.main' : 'divider',
-        borderRadius: 1,
+        borderRadius: 1.5,
+        boxShadow: (theme) =>
+          isFocused ? `0 0 0 3px ${alpha(theme.palette.primary.main, 0.16)}` : 'none',
         bgcolor: 'background.paper',
         color: 'text.primary',
         fontFamily: 'monospace',
@@ -199,8 +215,18 @@ export default function LogicInput({
             />
           ) : null}
           {i < len ? (
-            <Box component="span" data-char-index={i}>
-              {value[i]}
+            <Box
+              component="span"
+              data-char-index={i}
+              sx={{
+                display: 'inline-block',
+                minWidth: '0.7em',
+                minHeight: '1.35em',
+                px: '1px',
+                textAlign: 'center',
+              }}
+            >
+              {value[i] === ' ' ? '\u00a0' : value[i]}
             </Box>
           ) : null}
         </Box>

--- a/src/components/ui/LogicKeyboard/MobileLogicInput.jsx
+++ b/src/components/ui/LogicKeyboard/MobileLogicInput.jsx
@@ -3,9 +3,18 @@ import { createPortal, flushSync } from 'react-dom'
 import { Box, Button, Stack, TextField } from '@mui/material'
 import { alpha } from '@mui/material/styles'
 import { useTheme, useMediaQuery } from '@mui/material'
+import BackspaceOutlined from '@mui/icons-material/BackspaceOutlined'
+import ChevronLeft from '@mui/icons-material/ChevronLeft'
+import ChevronRight from '@mui/icons-material/ChevronRight'
+import FirstPage from '@mui/icons-material/FirstPage'
+import LastPage from '@mui/icons-material/LastPage'
 import FormulaInput from '../logicpenguin/formula-input.js'
 import LogicInput from './LogicInput.jsx'
-import SymbolButtonRow, { symbolRowButtonSx } from '../logicpenguin/SymbolButtonRow.jsx'
+import SymbolButtonRow, {
+  getMobileKeySx,
+  mobileKeyGridSx,
+  mobileKeyWellSx,
+} from '../logicpenguin/SymbolButtonRow.jsx'
 import getSyntax from '../../../lib/logicpenguin/symbolic/libsyntax.js'
 
 const DEFAULT_LETTERS = ['P', 'Q', 'R', 'S', 'T']
@@ -48,6 +57,24 @@ function isBinaryOp(symbolcat, op) {
   return symbolcat && typeof symbolcat[op] === 'number' && symbolcat[op] >= 2
 }
 
+function MobileNavKey({ label, onClick, disabled, kind = 'nav', children }) {
+  return (
+    <Button
+      type="button"
+      variant="text"
+      disableRipple
+      disableElevation
+      disabled={disabled}
+      onClick={onClick}
+      onMouseDown={(e) => e.preventDefault()}
+      aria-label={label}
+      sx={getMobileKeySx(kind)}
+    >
+      {children}
+    </Button>
+  )
+}
+
 /**
  * Variable letters for the mobile keyboard. Uses the DB symbolizationKey directly
  * (array of "Symbol = definition" strings); we do not parse premises.
@@ -67,9 +94,9 @@ function getVariableLettersOnly(symbolizationKey) {
 }
 
 /**
- * On mobile (sm down): LogicInput + SymbolButtonRow + a row of variable letters (symbol only, no definitions).
- * Letters are centered under the symbol row; definitions live in the question.
- * On desktop: renders children (existing native input).
+ * On mobile (sm down): LogicInput + a thumb-sized symbol keyboard.
+ * Glyphs come from getSyntax(notation). Pass the course/problem notation
+ * name when the engine exposes one (hurley, cambridge, forallx, …).
  */
 export default function MobileLogicInput({
   value,
@@ -89,6 +116,7 @@ export default function MobileLogicInput({
   predicateLetters,
   constantLetters,
   variableLetters: variableLettersProp,
+  notation,
   children,
 }) {
   const theme = useTheme()
@@ -100,6 +128,8 @@ export default function MobileLogicInput({
   const [isClosing, setIsClosing] = useState(false)
   const [slideIn, setSlideIn] = useState(false)
   const desktopInputRef = useRef(null)
+  const fieldWrapRef = useRef(null)
+  const panelRef = useRef(null)
 
   const onChangeRef = useRef(onChange)
   const setCursorRef = useRef(setCursorPosition)
@@ -110,7 +140,7 @@ export default function MobileLogicInput({
   valueRef.current = value ?? ''
   cursorRef.current = cursorPosition
 
-  const syntax = getSyntax()
+  const syntax = getSyntax(notation)
   const symbols = syntax?.symbols || {}
   const symbolcat = syntax?.symbolcat || {}
   const usePredicateLayout = Array.isArray(predicateLetters) && Array.isArray(constantLetters) && Array.isArray(variableLettersProp)
@@ -196,29 +226,37 @@ export default function MobileLogicInput({
     if (!keyboardFocused) setSlideIn(false)
   }, [keyboardFocused, slideIn])
 
+  useEffect(() => {
+    if (!keyboardFocused || !isVisible) return undefined
+    const field = fieldWrapRef.current
+    const panel = panelRef.current
+    if (!field) return undefined
+
+    const pad = panel?.offsetHeight || 220
+    const previousPad = document.body.style.paddingBottom
+    document.body.style.paddingBottom = `${pad}px`
+
+    const id = window.setTimeout(() => {
+      field.scrollIntoView({ block: 'center', behavior: 'smooth' })
+    }, 60)
+
+    return () => {
+      window.clearTimeout(id)
+      document.body.style.paddingBottom = previousPad
+    }
+  }, [keyboardFocused, isVisible])
+
   const handlePanelTransitionEnd = useCallback((e) => {
     if (e.propertyName === 'transform' && isClosing) setIsClosing(false)
   }, [isClosing])
 
-  const handleLetterInsert = useCallback(
-    (letter) => {
-      const f = facadeRef.current
-      if (!f) return
-      const start = f.selectionStart ?? 0
-      const end = f.selectionEnd ?? start
-      const val = f.value ?? ''
-      const newVal = val.slice(0, start) + letter + val.slice(end)
-      const newPos = start + letter.length
-      f.value = newVal
-      f.selectionStart = newPos
-      f.selectionEnd = newPos
-      valueRef.current = newVal
-      cursorRef.current = newPos
-      setCursorPosition(newPos)
-      onChange?.(newVal)
-    },
-    [onChange]
-  )
+  const handleLetterInsert = useCallback((letter) => {
+    const f = facadeRef.current
+    if (!f) return
+    const start = f.selectionStart ?? 0
+    const end = f.selectionEnd ?? start
+    f.setRangeText(letter, start, end, 'end')
+  }, [])
 
   useEffect(() => {
     const val = value ?? ''
@@ -250,6 +288,35 @@ export default function MobileLogicInput({
       f.setRangeText('', start, end, 'end')
     }
   }, [disabled])
+
+  const renderLetterButton = (letter, kind) => (
+    <Button
+      key={`${kind}-${letter}`}
+      type="button"
+      size="medium"
+      variant="text"
+      disableRipple
+      disableElevation
+      disabled={disabled}
+      aria-disabled={disabled}
+      onClick={() => handleLetterInsert(letter)}
+      onMouseDown={(e) => e.preventDefault()}
+      aria-label={kind === 'letter' ? `Insert ${letter}` : `Insert ${kind} ${letter}`}
+      title={`Insert ${letter}`}
+      sx={getMobileKeySx(kind)}
+    >
+      {letter}
+    </Button>
+  )
+
+  const letterRow = (letters, kind) => {
+    const cols = Math.min(Math.max(letters.length, 1), 6)
+    return (
+      <Box sx={mobileKeyGridSx(cols)}>
+        {letters.map((letter) => renderLetterButton(letter, kind))}
+      </Box>
+    )
+  }
 
   if (!isPhone) {
     return children ?? null
@@ -332,6 +399,8 @@ export default function MobileLogicInput({
             disabled={disabled}
             includeQuantifiers={includeQuantifiers}
             extraInsertButtons={extraInsertButtons}
+            mobileLayout
+            notation={notation}
           />
         </Box>
       </>
@@ -340,27 +409,30 @@ export default function MobileLogicInput({
 
   return (
     <>
-      <LogicInput
-        value={value ?? ''}
-        onChange={onChange}
-        onFocus={handleFocus}
-        onBlur={handleBlur}
-        cursorPosition={cursorPosition}
-        onCursorChange={(position) => {
-          setCursorPosition(position)
-          onCursorChange?.(position)
-        }}
-        disabled={disabled}
-        placeholder={placeholder}
-        aria-label={ariaLabel}
-      />
+      <Box ref={fieldWrapRef}>
+        <LogicInput
+          value={value ?? ''}
+          onChange={onChange}
+          onFocus={handleFocus}
+          onBlur={handleBlur}
+          cursorPosition={cursorPosition}
+          onCursorChange={(position) => {
+            setCursorPosition(position)
+            onCursorChange?.(position)
+          }}
+          disabled={disabled}
+          placeholder={placeholder}
+          aria-label={ariaLabel}
+        />
+      </Box>
       {showPanel && typeof document !== 'undefined'
         ? createPortal(
             <Box
+              ref={panelRef}
               onMouseDown={(e) => e.preventDefault()}
               onTransitionEnd={handlePanelTransitionEnd}
               role="region"
-              aria-label="Formula keyboard: insert logic symbols and letters, move cursor with arrow buttons"
+              aria-label="Logic keyboard"
               sx={{
                 position: 'fixed',
                 left: 0,
@@ -370,217 +442,107 @@ export default function MobileLogicInput({
                 boxSizing: 'border-box',
                 width: '100%',
                 maxWidth: '100vw',
-                p: 1.5,
-                pb: 'max(8px, env(safe-area-inset-bottom, 0px))',
-                bgcolor: (t) =>
+                px: 1,
+                pt: 0.75,
+                pb: 'max(10px, env(safe-area-inset-bottom, 0px))',
+                bgcolor: 'transparent',
+                backgroundImage: (t) =>
                   t.palette.mode === 'dark'
-                    ? alpha(t.palette.background.paper, 0.98)
-                    : t.palette.grey[100],
+                    ? `linear-gradient(180deg, ${alpha(t.palette.primary.main, 0.22)} 0%, ${alpha(t.palette.background.paper, 0.96)} 34%, ${t.palette.background.default} 100%)`
+                    : `linear-gradient(180deg, ${alpha(t.palette.primary.main, 0.14)} 0%, ${t.palette.grey[100]} 32%, ${t.palette.grey[300]} 100%)`,
                 borderTop: '1px solid',
-                borderColor: 'divider',
-                boxShadow: (t) => t.shadows[8],
+                borderColor: (t) => alpha(t.palette.primary.main, t.palette.mode === 'dark' ? 0.28 : 0.18),
+                boxShadow: (t) =>
+                  t.palette.mode === 'dark'
+                    ? '0 -12px 32px rgba(0,0,0,0.45)'
+                    : '0 -10px 28px rgba(83, 109, 254, 0.12), 0 -4px 12px rgba(15, 23, 42, 0.08)',
                 overflow: 'hidden',
-                borderTopLeftRadius: 12,
-                borderTopRightRadius: 12,
+                borderTopLeftRadius: 16,
+                borderTopRightRadius: 16,
                 transform: isVisible ? 'translateY(0)' : 'translateY(100%)',
                 transition: 'transform 0.28s ease-in-out',
                 willChange: 'transform',
+                '&::before': {
+                  content: '""',
+                  position: 'absolute',
+                  left: 0,
+                  right: 0,
+                  top: 0,
+                  height: 18,
+                  pointerEvents: 'none',
+                  background: (t) =>
+                    t.palette.mode === 'dark'
+                      ? 'linear-gradient(180deg, rgba(255,255,255,0.08) 0%, transparent 100%)'
+                      : 'linear-gradient(180deg, rgba(255,255,255,0.55) 0%, transparent 100%)',
+                },
                 '@media (prefers-reduced-motion: reduce)': {
                   transition: 'none',
                 },
               }}
             >
-          <Stack spacing={1} sx={{ width: '100%' }}>
-            <Box role="group" sx={{ width: '100%' }} aria-label="Logic symbols: connectives, quantifiers, parentheses">
-              <SymbolButtonRow
-                inputRef={facadeRef}
-                onValueChange={onChange}
-                disabled={disabled}
-                includeQuantifiers={includeQuantifiers}
-                showBackspace={false}
-                extraInsertButtons={extraInsertButtons}
-                centerButtons
-              />
-            </Box>
-            {usePredicateLayout ? (
               <Box
-                role="group"
-                sx={{ width: '100%' }}
-                aria-label="Letters: predicates, constants, variables. Tap to insert at cursor"
-              >
-                <Stack
-                  direction="row"
-                  spacing={0.5}
-                  flexWrap="wrap"
-                  useFlexGap
-                  justifyContent="center"
-                  sx={{ rowGap: 0.5 }}
-                >
-                  {predicateLetters.map((letter) => (
-                    <Button
-                      key={`pred-${letter}`}
-                      type="button"
-                      size="medium"
-                      variant="outlined"
-                      disabled={disabled}
-                      aria-disabled={disabled}
-                      onClick={() => handleLetterInsert(letter)}
-                      onMouseDown={(e) => e.preventDefault()}
-                      aria-label={`Insert predicate ${letter}`}
-                      title={`Insert ${letter}`}
-                      sx={symbolRowButtonSx}
-                    >
-                      {letter}
-                    </Button>
-                  ))}
-                  {constantLetters.map((letter) => (
-                    <Button
-                      key={`const-${letter}`}
-                      type="button"
-                      size="medium"
-                      variant="outlined"
-                      disabled={disabled}
-                      aria-disabled={disabled}
-                      onClick={() => handleLetterInsert(letter)}
-                      onMouseDown={(e) => e.preventDefault()}
-                      aria-label={`Insert constant ${letter}`}
-                      title={`Insert ${letter}`}
-                      sx={symbolRowButtonSx}
-                    >
-                      {letter}
-                    </Button>
-                  ))}
-                  {variableLettersProp.map((letter) => (
-                    <Button
-                      key={`var-${letter}`}
-                      type="button"
-                      size="medium"
-                      variant="outlined"
-                      disabled={disabled}
-                      aria-disabled={disabled}
-                      onClick={() => handleLetterInsert(letter)}
-                      onMouseDown={(e) => e.preventDefault()}
-                      aria-label={`Insert variable ${letter}`}
-                      title={`Insert ${letter}`}
-                      sx={symbolRowButtonSx}
-                    >
-                      {letter}
-                    </Button>
-                  ))}
-                </Stack>
-              </Box>
-            ) : (
-              <Box role="group" sx={{ width: '100%' }} aria-label="Variable letters: tap to insert at cursor">
-                <Stack
-                  direction="row"
-                  spacing={0.5}
-                  flexWrap="wrap"
-                  useFlexGap
-                  justifyContent="center"
-                >
-                  {variableLetters.map((letter) => (
-                    <Button
-                      key={letter}
-                      type="button"
-                      size="medium"
-                      variant="outlined"
-                      disabled={disabled}
-                      aria-disabled={disabled}
-                      onClick={() => handleLetterInsert(letter)}
-                      onMouseDown={(e) => e.preventDefault()}
-                      aria-label={`Insert ${letter}`}
-                      title={`Insert ${letter}`}
-                      sx={symbolRowButtonSx}
-                    >
-                      {letter}
-                    </Button>
-                  ))}
-                </Stack>
-              </Box>
-            )}
-            <Box role="group" sx={{ width: '100%' }} aria-label="Cursor navigation and backspace">
-              <Stack
-                direction="row"
-                spacing={0.5}
-                flexWrap="wrap"
-                useFlexGap
-                justifyContent="center"
-              >
-                <Button
-                  type="button"
-                  size="medium"
-                  variant="outlined"
-                  disabled={disabled}
-                  aria-disabled={disabled}
-                  onClick={handleNavStart}
-                  onMouseDown={(e) => e.preventDefault()}
-                  aria-label="Move cursor to start"
-                  title="Move cursor to start"
-                  sx={symbolRowButtonSx}
-                >
-                  ⇤
-                </Button>
-                <Button
-                  type="button"
-                  size="medium"
-                  variant="outlined"
-                  disabled={disabled}
-                  aria-disabled={disabled}
-                  onClick={handleNavLeft}
-                  onMouseDown={(e) => e.preventDefault()}
-                  aria-label="Move cursor left"
-                  title="Move cursor left"
-                  sx={symbolRowButtonSx}
-                >
-                  {'<'}
-                </Button>
-                <Button
-                  type="button"
-                  size="medium"
-                  variant="outlined"
-                  disabled={disabled}
-                  aria-disabled={disabled}
-                  onClick={handleNavRight}
-                  onMouseDown={(e) => e.preventDefault()}
-                  aria-label="Move cursor right"
-                  title="Move cursor right"
-                  sx={symbolRowButtonSx}
-                >
-                  {'>'}
-                </Button>
-                <Button
-                  type="button"
-                  size="medium"
-                  variant="outlined"
-                  disabled={disabled}
-                  aria-disabled={disabled}
-                  onClick={handleNavEnd}
-                  onMouseDown={(e) => e.preventDefault()}
-                  aria-label="Move cursor to end"
-                  title="Move cursor to end"
-                  sx={symbolRowButtonSx}
-                >
-                  ⇥
-                </Button>
-                <Button
-                  type="button"
-                  size="medium"
-                  variant="outlined"
-                  disabled={disabled}
-                  aria-disabled={disabled}
-                  onClick={handleBackspace}
-                  onMouseDown={(e) => e.preventDefault()}
-                  aria-label="Backspace"
-                  title="Backspace"
-                  sx={symbolRowButtonSx}
-                >
-                  ←
-                </Button>
+                aria-hidden
+                sx={{
+                  width: 36,
+                  height: 4,
+                  borderRadius: 2,
+                  bgcolor: 'text.disabled',
+                  opacity: 0.45,
+                  mx: 'auto',
+                  mb: 0.85,
+                  position: 'relative',
+                }}
+              />
+              <Stack spacing={1} sx={{ width: '100%', position: 'relative' }}>
+                <Box role="group" aria-label="Connectives and grouping" sx={mobileKeyWellSx('operators')}>
+                  <SymbolButtonRow
+                    inputRef={facadeRef}
+                    onValueChange={onChange}
+                    disabled={disabled}
+                    includeQuantifiers={includeQuantifiers}
+                    showBackspace={false}
+                    extraInsertButtons={extraInsertButtons}
+                    mobileLayout
+                    notation={notation}
+                  />
+                </Box>
+
+                {usePredicateLayout ? (
+                  <Box role="group" aria-label="Predicates, constants, and variables" sx={mobileKeyWellSx('letters')}>
+                    <Stack spacing={0.5}>
+                      {predicateLetters.length > 0 && letterRow(predicateLetters, 'predicate')}
+                      {constantLetters.length > 0 && letterRow(constantLetters, 'constant')}
+                      {variableLettersProp.length > 0 && letterRow(variableLettersProp, 'variable')}
+                    </Stack>
+                  </Box>
+                ) : (
+                  <Box role="group" aria-label="Letters" sx={mobileKeyWellSx('letters')}>
+                    {letterRow(variableLetters, 'letter')}
+                  </Box>
+                )}
+
+                <Box role="group" aria-label="Cursor and backspace" sx={mobileKeyWellSx('nav')}>
+                  <Box sx={mobileKeyGridSx(5)}>
+                    <MobileNavKey label="Move cursor to start" onClick={handleNavStart} disabled={disabled}>
+                      <FirstPage fontSize="small" />
+                    </MobileNavKey>
+                    <MobileNavKey label="Move cursor left" onClick={handleNavLeft} disabled={disabled}>
+                      <ChevronLeft fontSize="small" />
+                    </MobileNavKey>
+                    <MobileNavKey label="Move cursor right" onClick={handleNavRight} disabled={disabled}>
+                      <ChevronRight fontSize="small" />
+                    </MobileNavKey>
+                    <MobileNavKey label="Move cursor to end" onClick={handleNavEnd} disabled={disabled}>
+                      <LastPage fontSize="small" />
+                    </MobileNavKey>
+                    <MobileNavKey label="Backspace" onClick={handleBackspace} disabled={disabled} kind="backspace">
+                      <BackspaceOutlined fontSize="small" />
+                    </MobileNavKey>
+                  </Box>
+                </Box>
               </Stack>
-            </Box>
-          </Stack>
-        </Box>,
-            document.body
+            </Box>,
+            document.body,
           )
         : null}
     </>

--- a/src/components/ui/logicpenguin/LogicSymbol.jsx
+++ b/src/components/ui/logicpenguin/LogicSymbol.jsx
@@ -2,17 +2,26 @@ import { Box } from '@mui/material'
 
 const SYMBOL_SPEECH = {
   '~': 'tilde',
+  '¬': 'negation',
   '•': 'dot',
+  '∧': 'conjunction',
+  '&': 'ampersand',
   '∨': 'wedge',
   '⊃': 'horseshoe',
+  '→': 'arrow',
   '≡': 'triple bar',
+  '↔': 'biconditional',
   '∀': 'universal quantifier',
   '∃': 'existential quantifier',
+  '⊥': 'falsum',
+  '✖': 'falsum',
 }
 
 const EXPR_SPEECH = {
   '(∀x)': 'universal quantifier x',
   '(∃x)': 'existential quantifier x',
+  '∀x': 'universal quantifier x',
+  '∃x': 'existential quantifier x',
   '()': 'parentheses',
   '[]': 'brackets',
 }
@@ -76,11 +85,18 @@ export const getInsertSymbolLabel = ({ insert, pair } = {}) => {
   return `Insert ${insert}`
 }
 
-export default function LogicSymbol({ symbol, component = 'span', sx }) {
+export default function LogicSymbol({ symbol, component = 'span', sx, decorative = false }) {
+  if (decorative) {
+    return (
+      <Box component={component} aria-hidden sx={sx}>
+        {symbol}
+      </Box>
+    )
+  }
   const expressionSpeech = EXPR_SPEECH[symbol]
   const symbolSpeech = expressionSpeech || getTokenSpeechLabel(symbol)
   return (
-    <Box component={component} role="text" aria-label={symbolSpeech} sx={sx}>
+    <Box component={component} aria-label={symbolSpeech} sx={sx}>
       <Box component="span" aria-hidden="true">{symbol}</Box>
     </Box>
   )

--- a/src/components/ui/logicpenguin/SymbolButtonRow.jsx
+++ b/src/components/ui/logicpenguin/SymbolButtonRow.jsx
@@ -26,7 +26,59 @@ const BUTTONS = [
   { backspace: true },
 ]
 
-/** Shared sx for symbol, variable, and navigation keyboard buttons. */
+const fill = (theme, light, dark) => (theme.palette.mode === 'dark' ? dark : light)
+
+const hueTone = (paletteKey, lightFill, darkFill) => ({
+  bgcolor: (theme) => alpha(theme.palette[paletteKey].main, fill(theme, lightFill, darkFill)),
+  borderColor: (theme) => alpha(theme.palette[paletteKey].main, fill(theme, lightFill + 0.16, darkFill + 0.12)),
+  color: 'text.primary',
+  '@media (hover: hover) and (pointer: fine)': {
+    '&:hover': {
+      bgcolor: (theme) => alpha(theme.palette[paletteKey].main, fill(theme, lightFill + 0.07, darkFill + 0.08)),
+      borderColor: (theme) => alpha(theme.palette[paletteKey].main, 0.5),
+      boxShadow: 'none',
+    },
+  },
+  '&:active': {
+    bgcolor: (theme) => alpha(theme.palette[paletteKey].main, fill(theme, lightFill + 0.12, darkFill + 0.12)),
+    borderColor: (theme) => theme.palette[paletteKey].main,
+    boxShadow: 'none',
+    transform: 'scale(0.97)',
+  },
+})
+
+const utilityTone = (emphasis = false) => ({
+  bgcolor: (theme) => {
+    if (theme.palette.mode === 'dark') {
+      return alpha(theme.palette.common.white, emphasis ? 0.14 : 0.08)
+    }
+    return emphasis ? theme.palette.grey[300] : theme.palette.grey[200]
+  },
+  borderColor: (theme) =>
+    alpha(theme.palette.common.black, theme.palette.mode === 'dark' ? 0.2 : 0.08),
+  color: emphasis ? 'text.primary' : 'text.secondary',
+  boxShadow: 'none',
+  '@media (hover: hover) and (pointer: fine)': {
+    '&:hover': {
+      bgcolor: (theme) =>
+        theme.palette.mode === 'dark'
+          ? alpha(theme.palette.common.white, emphasis ? 0.2 : 0.14)
+          : theme.palette.grey[emphasis ? 400 : 300],
+      borderColor: 'divider',
+      boxShadow: 'none',
+    },
+  },
+  '&:active': {
+    bgcolor: (theme) =>
+      theme.palette.mode === 'dark'
+        ? alpha(theme.palette.common.white, 0.22)
+        : theme.palette.grey[400],
+    boxShadow: 'none',
+    transform: 'scale(0.97)',
+  },
+})
+
+/** Compact buttons for the desktop symbol toolbar. */
 export const symbolRowButtonSx = {
   minWidth: 34,
   height: 34,
@@ -38,16 +90,104 @@ export const symbolRowButtonSx = {
   fontWeight: 600,
   textTransform: 'none',
   boxShadow: 'none',
-  border: 'none',
   display: 'inline-flex',
   alignItems: 'center',
   justifyContent: 'center',
   '& .MuiButton-label': { fontSize: '1rem' },
-  '&:hover': (theme) => ({
-    boxShadow: 'none',
-    border: 'none',
-    backgroundColor: alpha(theme.palette.primary.main, theme.palette.action.hoverOpacity),
-  }),
+  '@media (hover: hover) and (pointer: fine)': {
+    '&:hover': {
+      boxShadow: 'none',
+      backgroundColor: (theme) => alpha(theme.palette.primary.main, theme.palette.action.hoverOpacity),
+    },
+  },
+  '&:active': {
+    backgroundColor: (theme) => alpha(theme.palette.primary.main, 0.14),
+  },
+}
+
+/** Shared layout for phone keys. Color comes from getMobileKeySx(kind). */
+export const mobileKeyBaseSx = {
+  minWidth: 0,
+  width: '100%',
+  minHeight: 44,
+  height: 44,
+  px: 0.25,
+  py: 0,
+  fontSize: '1.2rem',
+  lineHeight: 1,
+  fontWeight: 600,
+  textTransform: 'none',
+  color: 'text.primary',
+  borderRadius: 1.75,
+  border: '1px solid',
+  boxShadow: (theme) =>
+    theme.palette.mode === 'dark'
+      ? 'inset 0 1px 0 rgba(255,255,255,0.08)'
+      : 'inset 0 1px 0 rgba(255,255,255,0.72)',
+  touchAction: 'manipulation',
+  WebkitTapHighlightColor: 'transparent',
+  transition: (theme) =>
+    theme.transitions.create(['background-color', 'border-color', 'transform'], {
+      duration: 90,
+    }),
+  display: 'inline-flex',
+  alignItems: 'center',
+  justifyContent: 'center',
+  '& .MuiButton-label': { fontSize: '1.2rem' },
+  '&.Mui-focusVisible': {
+    outline: '2px solid',
+    outlineColor: 'primary.main',
+    outlineOffset: 1,
+  },
+  '&.Mui-disabled': {
+    opacity: 0.38,
+  },
+  '@media (prefers-reduced-motion: reduce)': {
+    transition: 'none',
+    '&:active': { transform: 'none' },
+  },
+}
+
+const mobileKeyToneSx = {
+  connective: hueTone('primary', 0.12, 0.24),
+  grouping: hueTone('info', 0.1, 0.22),
+  extra: hueTone('primary', 0.06, 0.16),
+  predicate: hueTone('warning', 0.18, 0.22),
+  constant: hueTone('success', 0.14, 0.2),
+  variable: hueTone('info', 0.12, 0.22),
+  letter: hueTone('primary', 0.08, 0.2),
+  nav: utilityTone(false),
+  backspace: utilityTone(true),
+}
+
+export const getMobileKeySx = (kind = 'letter') => [
+  mobileKeyBaseSx,
+  mobileKeyToneSx[kind] || mobileKeyToneSx.letter,
+]
+
+export const mobileKeyGridSx = (columns) => ({
+  display: 'grid',
+  gridTemplateColumns: `repeat(${columns}, minmax(0, 1fr))`,
+  gap: 0.5,
+  width: '100%',
+})
+
+export const mobileKeyWellSx = (kind = 'letters') => {
+  const tint =
+    kind === 'operators'
+      ? (theme) => alpha(theme.palette.primary.main, theme.palette.mode === 'dark' ? 0.14 : 0.07)
+      : kind === 'nav'
+        ? (theme) => alpha(theme.palette.common.black, theme.palette.mode === 'dark' ? 0.28 : 0.06)
+        : (theme) => alpha(theme.palette.common.black, theme.palette.mode === 'dark' ? 0.22 : 0.04)
+  return {
+    p: 0.75,
+    borderRadius: 2,
+    bgcolor: tint,
+    boxShadow: (theme) =>
+      theme.palette.mode === 'dark'
+        ? 'inset 0 1px 2px rgba(0,0,0,0.35)'
+        : 'inset 0 1px 2px rgba(15, 23, 42, 0.06)',
+  }
 }
 
 export default function SymbolButtonRow({
@@ -59,10 +199,20 @@ export default function SymbolButtonRow({
   showBackspace = true,
   extraInsertButtons,
   centerButtons = false,
+  /** Equal-width grid rows sized for thumbs. */
+  mobileLayout = false,
+  notation,
 }) {
-  const syntax = getSyntax()
-  const inputSymbols = inputRef?.current?.symbols
-  const symbols = inputSymbols || syntax?.symbols || {}
+  const syntax = getSyntax(notation)
+  const symbols = syntax?.symbols || inputRef?.current?.symbols || {}
+
+  const quantifierText = (op) => {
+    const sym = symbols?.[op] || FALLBACK_SYMBOLS[op] || op
+    if (typeof syntax?.mkquantifier === 'function') {
+      return syntax.mkquantifier('x', sym)
+    }
+    return `(${sym}x)`
+  }
 
   const resolveLabel = (op, quantifier = false, insert = null, pair = null, backspace = false) => {
     if (backspace) return '←'
@@ -72,8 +222,8 @@ export default function SymbolButtonRow({
       const close = pair[1]
       return `${open}  ${close}`
     }
-    const sym = symbols?.[op] || FALLBACK_SYMBOLS[op] || op
-    return quantifier ? `(${sym}x)` : sym
+    if (quantifier) return quantifierText(op)
+    return symbols?.[op] || FALLBACK_SYMBOLS[op] || op
   }
 
   const finalizeChange = (input) => {
@@ -89,8 +239,7 @@ export default function SymbolButtonRow({
   }
 
   const insertQuantifier = (input, op) => {
-    const sym = symbols?.[op] || FALLBACK_SYMBOLS[op] || op
-    const text = `(${sym}x)`
+    const text = quantifierText(op)
     const start = input.selectionStart ?? input.value.length
     const end = input.selectionEnd ?? start
     input.setRangeText(text, start, end, 'end')
@@ -164,8 +313,10 @@ export default function SymbolButtonRow({
       finalizeChange(input)
       return
     }
-    if (typeof input.insOp !== 'function') return
-    input.insOp(op)
+    const sym = symbols?.[op]
+    if (!sym) return
+    const text = (syntax?.symbolcat?.[op] ?? 0) >= 2 ? ` ${sym} ` : sym
+    insertLiteral(input, text)
     finalizeChange(input)
   }
 
@@ -175,12 +326,71 @@ export default function SymbolButtonRow({
   const baseButtons = showBackspace
     ? baseButtonsRaw
     : baseButtonsRaw.filter((btn) => !btn.backspace)
+  const extras = extraInsertButtons || []
   const visibleButtons = baseButtons.length > 0 && baseButtons[baseButtons.length - 1].backspace
-    ? [...baseButtons.slice(0, -1), ...(extraInsertButtons || []), { backspace: true }]
-    : [...baseButtons, ...(extraInsertButtons || [])]
+    ? [...baseButtons.slice(0, -1), ...extras, { backspace: true }]
+    : [...baseButtons, ...extras]
+
+  const renderButton = (btn, kind = 'connective') => {
+    const { op, quantifier, insert, pair, backspace } = btn
+    const visualSymbol = resolveLabel(op, quantifier, insert, pair, backspace)
+    const a11yLabel = backspace
+      ? 'Backspace'
+      : getInsertSymbolLabel({
+          insert: pair ? null : visualSymbol,
+          pair,
+        })
+    return (
+      <Button
+        key={backspace ? 'backspace' : (op || insert || pair)}
+        type="button"
+        size="medium"
+        variant={mobileLayout ? 'text' : 'outlined'}
+        disableRipple={mobileLayout}
+        disableElevation={mobileLayout}
+        onMouseDown={(e) => e.preventDefault()}
+        onClick={() => handleInsert({ op, quantifier, insert, pair, backspace })}
+        disabled={disabled}
+        aria-disabled={disabled}
+        aria-label={a11yLabel}
+        title={a11yLabel}
+        sx={mobileLayout ? getMobileKeySx(kind) : symbolRowButtonSx}
+      >
+        <LogicSymbol symbol={visualSymbol} decorative />
+      </Button>
+    )
+  }
+
+  if (mobileLayout) {
+    const connectives = visibleButtons.filter((btn) => btn.op && !btn.quantifier)
+    const grouping = visibleButtons.filter((btn) => btn.quantifier || btn.pair)
+    const extraRow = visibleButtons.filter((btn) => btn.insert)
+    const backspaceBtn = visibleButtons.find((btn) => btn.backspace)
+
+    return (
+      <Box aria-label="Symbol shortcuts" role="group" sx={{ display: 'flex', flexDirection: 'column', gap: 0.5 }}>
+        {connectives.length > 0 && (
+          <Box sx={mobileKeyGridSx(connectives.length)}>
+            {connectives.map((btn) => renderButton(btn, 'connective'))}
+          </Box>
+        )}
+        {grouping.length > 0 && (
+          <Box sx={mobileKeyGridSx(grouping.length)}>
+            {grouping.map((btn) => renderButton(btn, 'grouping'))}
+          </Box>
+        )}
+        {extraRow.length > 0 && (
+          <Box sx={mobileKeyGridSx(Math.min(extraRow.length, 4))}>
+            {extraRow.map((btn) => renderButton(btn, 'extra'))}
+          </Box>
+        )}
+        {backspaceBtn ? <Box sx={mobileKeyGridSx(1)}>{renderButton(backspaceBtn, 'backspace')}</Box> : null}
+      </Box>
+    )
+  }
 
   return (
-    <Box aria-label="Symbol shortcuts">
+    <Box aria-label="Symbol shortcuts" role="group">
       <Stack
         direction="row"
         spacing={0.5}
@@ -188,30 +398,7 @@ export default function SymbolButtonRow({
         useFlexGap
         sx={centerButtons ? { justifyContent: 'center' } : undefined}
       >
-        {visibleButtons.map(({ op, quantifier, insert, pair, backspace }) => {
-          const visualSymbol = resolveLabel(op, quantifier, insert, pair, backspace)
-          const a11yLabel = backspace ? 'Backspace' : getInsertSymbolLabel({
-            insert: pair ? null : visualSymbol,
-            pair,
-          })
-          return (
-            <Button
-              key={backspace ? 'backspace' : (op || insert || pair)}
-              type="button"
-              size="medium"
-              variant="outlined"
-              onMouseDown={(e) => e.preventDefault()}
-              onClick={() => handleInsert({ op, quantifier, insert, pair, backspace })}
-              disabled={disabled}
-              aria-disabled={disabled}
-              aria-label={a11yLabel}
-              title={a11yLabel}
-              sx={symbolRowButtonSx}
-            >
-              <LogicSymbol symbol={visualSymbol} />
-            </Button>
-          )
-        })}
+        {visibleButtons.map(renderButton)}
       </Stack>
     </Box>
   )

--- a/src/components/ui/logicpenguin/formula-input.js
+++ b/src/components/ui/logicpenguin/formula-input.js
@@ -156,7 +156,7 @@ export default class FormulaInput {
         elem.autoChange = FormulaInput.autoChange;
 
         // attach syntax, symbols and inputfix
-        const syntax = getSyntax();
+        const syntax = options.syntax?.symbols ? options.syntax : getSyntax(options);
         elem.syntax = syntax;
         elem.symbols = syntax.symbols;
         elem.inputfix = syntax.inputfix;

--- a/src/lib/logicpenguin/symbolic/libsyntax.js
+++ b/src/lib/logicpenguin/symbolic/libsyntax.js
@@ -10,7 +10,6 @@
 import notations from './notations.js';
 
 const DEFAULT_NOTATION = 'hurley';
-let cachedSyntax = null;
 
 // adicities for operators
 const symbolcat = {
@@ -154,12 +153,13 @@ function stripmatching(s) {
 }
 
 //////////// Main function for generating new syntax
-function generateSyntax() {
+function generateSyntax(notationName = DEFAULT_NOTATION) {
     // initialize return value
     const syntax = {};
+    const name = notations[notationName] ? notationName : DEFAULT_NOTATION;
 
-    syntax.notation = notations[DEFAULT_NOTATION];
-    syntax.notationname = DEFAULT_NOTATION;
+    syntax.notation = notations[name];
+    syntax.notationname = name;
 
     // symbols are those things in notation also in symbolcat
     const symbols = {}
@@ -228,17 +228,34 @@ function generateSyntax() {
     syntax.symbolcat = symbolcat;
     return syntax;
 }
-//
-// EXPORTED FUNCTION
-//
-// returns the app's (single) syntax object
-export default function getSyntax() {
-    if (cachedSyntax) {
-        // regenerate if notation has changed (e.g., updated ranges)
-        if (cachedSyntax?.notation?.predicatesRange?.includes('a')) {
-            return cachedSyntax;
-        }
-    }
-    cachedSyntax = generateSyntax();
-    return cachedSyntax;
+const syntaxCache = new Map();
+
+function normalizeNotationName(raw) {
+    if (typeof raw !== 'string') return undefined;
+    const name = raw.trim().toLowerCase();
+    return notations[name] ? name : undefined;
+}
+
+/** Accepts a notation id (`'cambridge'`) or a proof/problem object. */
+export function resolveNotationName(source) {
+    if (source == null) return undefined;
+    if (typeof source === 'string') return normalizeNotationName(source);
+    if (typeof source !== 'object') return undefined;
+    return normalizeNotationName(
+        (typeof source.notation === 'string' && source.notation) ||
+        source.options?.notation ||
+        source.questionSnapshot?.options?.notation ||
+        source.snapshot?.options?.notation ||
+        source.question_snapshot?.options?.notation
+    );
+}
+
+// returns a syntax object for the given notation (default: Hurley)
+export default function getSyntax(notationName) {
+    const name = resolveNotationName(notationName) || DEFAULT_NOTATION;
+    const cached = syntaxCache.get(name);
+    if (cached) return cached;
+    const syntax = generateSyntax(name);
+    syntaxCache.set(name, syntax);
+    return syntax;
 }

--- a/src/lib/logicpenguin/symbolic/notations.js
+++ b/src/lib/logicpenguin/symbolic/notations.js
@@ -3,8 +3,26 @@
 // https://www.gnu.org/licenses/.
 
 ////////////////// notations.js ///////////////////////////
-// This app uses a single notation: Hurley.           //
+// Textbook glyph tables. Add a key here and pass that
+// name to getSyntax() / the keyboard `notation` prop.
 ///////////////////////////////////////////////////////////
+
+const cambridge = {
+    OR      : '∨',
+    AND     : '∧',
+    IFTHEN  : '→',
+    IFF     : '↔',
+    NOT     : '¬',
+    FORALL  : '∀',
+    EXISTS  : '∃',
+    FALSUM  : '⊥',
+    constantsRange: 'a-w',
+    predicatesRange: '=≠A-Z',
+    quantifierForm: 'Qx',
+    schematicLetters: '𝒜𝒜𝓍𝒶𝓃',
+    useTermParensCommas: false,
+    variableRange: 'x-z'
+}
 
 const notations = {
     hurley: {
@@ -23,6 +41,8 @@ const notations = {
         useTermParensCommas: false,
         variableRange: 'x-z'
     },
+    cambridge,
+    forallx: cambridge,
     nonclassical: {
         OR      : 'V',
         AND     : '&',


### PR DESCRIPTION
## Description

Mobile logic keyboard polish (grouped wells, light color coding, no row labels) plus notation-aware symbol inserts so Hurley / Cambridge / forall x can share one keyboard.

Unknown or missing notation still falls back to Hurley.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [x] Refactor / Chore

## How to Test

1. `npm run dev`, phone viewport (`sm` and down).
2. Open a propositional derivation, a predicate derivation, and a symbolic translation. Confirm three wells (operators / letters / nav), amber–teal–violet letter rows on predicate problems, and that tap still works.
3. On a problem with `options.notation: "cambridge"` (or `"forallx"`), confirm keys insert `¬ ∧ → ↔` (and `∀x` / `∃x`, not Hurley `~ • ⊃ ≡`).
4. Same problem with no `notation` (or `"hurley"`): `~ • ⊃ ≡` and `(∀x)`-style inserts as today.
5. Desktop: symbol row and formula field still work; `/` and `//` still appear on combo argument lines.

## Cross-engine notation (plug and play)

Pass a name on the problem/proof. The keyboard already reads it:

```js
options.notation // 'hurley' | 'cambridge' | 'forallx'
```

```js
import getSyntax, { resolveNotationName } from '…/libsyntax.js'

const notation = resolveNotationName(proof) // also accepts 'Cambridge', or the proof object
<MobileLogicInput notation={notation} />
FormulaInput.getnew({ notation })
// or FormulaInput.getnew({ syntax: getSyntax(notation) })
```

`getSyntax()` with no args is still Hurley. Unknown names also fall back to Hurley.

To add a textbook, add a key in `src/lib/logicpenguin/symbolic/notations.js` with `NOT`, `AND`, `OR`, `IFTHEN`, `IFF`, `FORALL`, `EXISTS` (and `quantifierForm` if needed). No keyboard UI changes.