### PR TITLE
classwide extensions and extension viewing table

### DIFF
--- a/src/components/layout/SandboxLayout.jsx
+++ b/src/components/layout/SandboxLayout.jsx
@@ -160,6 +160,8 @@ export function InstructorSandboxLayout({ children }) {
       saveAccommodations: sandbox.saveAccommodations,
       getDeadlines: sandbox.getDeadlines,
       saveDeadline: sandbox.saveDeadline,
+      getAssignmentExtensions: sandbox.getAssignmentExtensions,
+      saveClasswideExtension: sandbox.saveClasswideExtension,
       loadInstructorDashboard: async (courseId) => {
         const snapshot = sandbox.dashboardAnalyticsByCourse?.[courseId];
         return {

--- a/src/components/ui/AssignmentContextMenu.jsx
+++ b/src/components/ui/AssignmentContextMenu.jsx
@@ -1,5 +1,5 @@
 import { Menu, MenuItem } from "@mui/material";
-import { FileEdit, Edit, Copy, Trash2 } from "lucide-react";
+import { FileEdit, Edit, Copy, Trash2, CalendarClock, List } from "lucide-react";
 
 export default function AssignmentContextMenu({
   anchorEl,
@@ -10,7 +10,14 @@ export default function AssignmentContextMenu({
   onEdit,
   onDuplicate,
   onDelete,
+  onClasswideExtension,
+  onViewExtensions,
 }) {
+  const select = (handler) => () => {
+    onClose?.();
+    handler?.(item);
+  };
+
   return (
     <Menu
       anchorEl={anchorEl}
@@ -19,19 +26,37 @@ export default function AssignmentContextMenu({
       anchorOrigin={{ vertical: "bottom", horizontal: "right" }}
       transformOrigin={{ vertical: "top", horizontal: "right" }}
     >
-      <MenuItem onClick={() => onOpenBuilder(item)}>
+      <MenuItem onClick={select(onOpenBuilder)}>
         <FileEdit size={16} style={{ marginRight: 8 }} />
         Open Builder
       </MenuItem>
-      <MenuItem onClick={() => onEdit(item)}>
+      <MenuItem onClick={select(onEdit)}>
         <Edit size={16} style={{ marginRight: 8 }} />
         Edit Settings
       </MenuItem>
-      <MenuItem onClick={() => onDuplicate(item)}>
+      {onClasswideExtension && (
+        <MenuItem onClick={select(onClasswideExtension)}>
+          <CalendarClock size={16} style={{ marginRight: 8 }} />
+          Classwide extension
+        </MenuItem>
+      )}
+      {onViewExtensions && (
+        <MenuItem onClick={select(onViewExtensions)}>
+          <List size={16} style={{ marginRight: 8 }} />
+          View extensions
+        </MenuItem>
+      )}
+      <MenuItem onClick={select(onDuplicate)}>
         <Copy size={16} style={{ marginRight: 8 }} />
         Duplicate
       </MenuItem>
-      <MenuItem onClick={() => onDelete(item?.id)} sx={{ color: "error.main" }}>
+      <MenuItem
+        onClick={() => {
+          onClose?.();
+          onDelete?.(item?.id);
+        }}
+        sx={{ color: "error.main" }}
+      >
         <Trash2 size={16} style={{ marginRight: 8 }} />
         Delete
       </MenuItem>

--- a/src/components/ui/assignments/AssignmentExtensionsDialog.jsx
+++ b/src/components/ui/assignments/AssignmentExtensionsDialog.jsx
@@ -1,0 +1,88 @@
+import { useEffect, useRef, useState } from "react";
+import {
+  Alert,
+  Box,
+  Button,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogTitle,
+  LinearProgress,
+  Typography,
+} from "@mui/material";
+import AssignmentExtensionsTable from "./AssignmentExtensionsTable.jsx";
+
+export default function AssignmentExtensionsDialog({
+  open,
+  assignment,
+  loadExtensions,
+  onClose,
+  onClasswide,
+}) {
+  const [rows, setRows] = useState([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState("");
+  const loadRef = useRef(loadExtensions);
+  loadRef.current = loadExtensions;
+
+  useEffect(() => {
+    if (!open || !assignment?.id) return undefined;
+    const load = loadRef.current;
+    if (typeof load !== "function") {
+      setRows([]);
+      setError("Extensions are not available.");
+      return undefined;
+    }
+
+    let cancelled = false;
+    setError("");
+    setLoading(true);
+    load(assignment.id)
+      .then((data) => {
+        if (!cancelled) setRows(Array.isArray(data) ? data : []);
+      })
+      .catch((err) => {
+        if (!cancelled) {
+          setRows([]);
+          setError(err?.message || "Failed to load extensions.");
+        }
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false);
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [open, assignment?.id]);
+
+  return (
+    <Dialog open={open} onClose={onClose} maxWidth="md" fullWidth>
+      <DialogTitle>Assignment extensions</DialogTitle>
+      {loading && <LinearProgress />}
+      <DialogContent>
+        {assignment?.name && (
+          <Typography variant="body2" color="text.secondary" sx={{ mb: 2 }}>
+            {assignment.name}
+          </Typography>
+        )}
+        {error && (
+          <Alert severity="error" sx={{ mb: 2 }}>
+            {error}
+          </Alert>
+        )}
+        <AssignmentExtensionsTable rows={rows} />
+      </DialogContent>
+      <DialogActions>
+        {onClasswide && (
+          <Box sx={{ mr: "auto" }}>
+            <Button onClick={onClasswide} disabled={loading}>
+              Classwide extension
+            </Button>
+          </Box>
+        )}
+        <Button onClick={onClose}>Close</Button>
+      </DialogActions>
+    </Dialog>
+  );
+}

--- a/src/components/ui/assignments/AssignmentExtensionsTable.jsx
+++ b/src/components/ui/assignments/AssignmentExtensionsTable.jsx
@@ -1,0 +1,86 @@
+import {
+  Box,
+  Paper,
+  Table,
+  TableHead,
+  TableRow,
+  TableCell,
+  TableBody,
+  Typography,
+  alpha,
+} from "@mui/material";
+import { CalendarClock } from "lucide-react";
+import { formatEasternFromIso } from "../../../utils/easternTime.js";
+
+function studentName(row) {
+  return row.User?.username || row.user?.username || `User ${row.user_id}`;
+}
+
+function grantedByName(row) {
+  return row.grantedBy?.username || row.granted_by_user?.username || "—";
+}
+
+export default function AssignmentExtensionsTable({ rows = [] }) {
+  if (rows.length === 0) {
+    return (
+      <Paper
+        elevation={0}
+        sx={{
+          borderRadius: 3,
+          border: "1px solid",
+          borderColor: "divider",
+          textAlign: "center",
+          py: 6,
+        }}
+      >
+        <CalendarClock size={40} style={{ opacity: 0.4, marginBottom: 12 }} />
+        <Typography color="text.secondary">
+          No extensions for this assignment yet
+        </Typography>
+      </Paper>
+    );
+  }
+
+  return (
+    <Paper
+      elevation={0}
+      sx={{
+        borderRadius: 3,
+        border: "1px solid",
+        borderColor: "divider",
+        overflow: "hidden",
+      }}
+    >
+      <Box sx={{ overflowX: "auto" }}>
+        <Table size="small">
+          <TableHead>
+            <TableRow sx={{ backgroundColor: alpha("#000", 0.02) }}>
+              <TableCell sx={{ fontWeight: 600 }}>Student</TableCell>
+              <TableCell sx={{ fontWeight: 600 }}>Extended due</TableCell>
+              <TableCell sx={{ fontWeight: 600 }}>Reason</TableCell>
+              <TableCell sx={{ fontWeight: 600 }}>Granted by</TableCell>
+              <TableCell sx={{ fontWeight: 600 }}>Granted</TableCell>
+            </TableRow>
+          </TableHead>
+          <TableBody>
+            {rows.map((row) => (
+              <TableRow key={row.id ?? `${row.assignment_id}-${row.user_id}`} hover>
+                <TableCell>{studentName(row)}</TableCell>
+                <TableCell>
+                  {formatEasternFromIso(row.extended_due_date, { includeTime: true }) || "—"}
+                </TableCell>
+                <TableCell sx={{ maxWidth: 240, whiteSpace: "normal", wordBreak: "break-word" }}>
+                  {row.reason?.trim() ? row.reason : "—"}
+                </TableCell>
+                <TableCell>{grantedByName(row)}</TableCell>
+                <TableCell>
+                  {formatEasternFromIso(row.created_at, { includeTime: true }) || "—"}
+                </TableCell>
+              </TableRow>
+            ))}
+          </TableBody>
+        </Table>
+      </Box>
+    </Paper>
+  );
+}

--- a/src/components/ui/assignments/ClasswideExtensionDialog.jsx
+++ b/src/components/ui/assignments/ClasswideExtensionDialog.jsx
@@ -1,0 +1,99 @@
+import {
+  Alert,
+  Button,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogTitle,
+  LinearProgress,
+  Stack,
+  TextField,
+  Typography,
+} from "@mui/material";
+
+const REASON_MAX_LENGTH = 500;
+
+export default function ClasswideExtensionDialog({
+  open,
+  assignment,
+  form,
+  onChange,
+  onClose,
+  onSubmit,
+  saving = false,
+  error = "",
+}) {
+  const canSubmit = Boolean(form?.dueDate) && !saving;
+
+  const handleSubmit = (event) => {
+    event?.preventDefault?.();
+    if (!canSubmit) return;
+    onSubmit?.();
+  };
+
+  return (
+    <Dialog
+      open={open}
+      onClose={saving ? undefined : onClose}
+      maxWidth="xs"
+      fullWidth
+    >
+      <form onSubmit={handleSubmit}>
+        <DialogTitle>Classwide extension</DialogTitle>
+        {saving && <LinearProgress />}
+        <DialogContent>
+          <Stack spacing={2} sx={{ mt: 0.5 }}>
+            {assignment?.name && (
+              <Typography variant="body2" color="text.secondary">
+                {assignment.name}
+              </Typography>
+            )}
+            <Alert severity="warning">
+              This sets the same extended due date for every enrolled student. Existing
+              per-student extensions for this assignment will be overwritten.
+            </Alert>
+            {error && <Alert severity="error">{error}</Alert>}
+            <TextField
+              label="Extended due date"
+              type="date"
+              value={form?.dueDate || ""}
+              onChange={(e) => onChange({ dueDate: e.target.value })}
+              fullWidth
+              required
+              disabled={saving}
+              InputLabelProps={{ shrink: true }}
+            />
+            <TextField
+              label="Extended due time"
+              type="time"
+              value={form?.dueTime || "23:59"}
+              onChange={(e) => onChange({ dueTime: e.target.value })}
+              fullWidth
+              disabled={saving}
+              InputLabelProps={{ shrink: true }}
+            />
+            <TextField
+              label="Reason (optional)"
+              value={form?.reason || ""}
+              onChange={(e) => onChange({ reason: e.target.value.slice(0, REASON_MAX_LENGTH) })}
+              fullWidth
+              multiline
+              minRows={2}
+              disabled={saving}
+              inputProps={{ maxLength: REASON_MAX_LENGTH }}
+              helperText={`${(form?.reason || "").length}/${REASON_MAX_LENGTH}`}
+            />
+          </Stack>
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={onClose} disabled={saving}>
+            Cancel
+          </Button>
+          <Button type="submit" variant="contained" disabled={!canSubmit}>
+            Apply to class
+          </Button>
+        </DialogActions>
+      </form>
+    </Dialog>
+  );
+}

--- a/src/components/ui/assignments/ClasswideExtensionDialog.jsx
+++ b/src/components/ui/assignments/ClasswideExtensionDialog.jsx
@@ -48,9 +48,9 @@ export default function ClasswideExtensionDialog({
                 {assignment.name}
               </Typography>
             )}
-            <Alert severity="warning">
-              This sets the same extended due date for every enrolled student. Existing
-              per-student extensions for this assignment will be overwritten.
+            <Alert severity="info">
+              Applies this due date to enrolled students. Anyone with an individual extension
+              that ends later will keep that later date.
             </Alert>
             {error && <Alert severity="error">{error}</Alert>}
             <TextField

--- a/src/context/InstructorSandboxContext.jsx
+++ b/src/context/InstructorSandboxContext.jsx
@@ -673,15 +673,27 @@ export function InstructorSandboxProvider({ children }) {
     if (!extendedDueDate || Number.isNaN(Date.parse(extendedDueDate))) {
       throw new Error("A valid extended due date is required.")
     }
+    const classwideMs = Date.parse(extendedDueDate)
     const courseId = courseState.activeCourseId
     const students = (courseState.gradebookByCourse?.[courseId] || []).filter(
       (student) => String(student.role || "student").toLowerCase() !== "ta"
     )
     const grantedAt = new Date().toISOString()
     const trimmedReason = typeof reason === "string" ? reason.trim().slice(0, 500) : null
+    let updated = 0
+    let preserved = 0
+
     setState((prev) => {
       const courseDeadlines = { ...(prev.deadlinesByCourse?.[courseId] || {}) }
       for (const student of students) {
+        const existing = courseDeadlines[student.id]?.[assignmentId]
+        const existingMs = existing?.extension_due_at
+          ? Date.parse(existing.extension_due_at)
+          : NaN
+        if (existing?.extension_due_at && !Number.isNaN(existingMs) && existingMs > classwideMs) {
+          preserved += 1
+          continue
+        }
         courseDeadlines[student.id] = {
           ...(courseDeadlines[student.id] || {}),
           [assignmentId]: {
@@ -692,6 +704,7 @@ export function InstructorSandboxProvider({ children }) {
             created_at: grantedAt,
           },
         }
+        updated += 1
       }
       return {
         ...prev,
@@ -701,7 +714,7 @@ export function InstructorSandboxProvider({ children }) {
         },
       }
     })
-    return { updated: students.length }
+    return { updated, preserved, total: students.length }
   }
 
   const getActivity = (activityId) => {

--- a/src/context/InstructorSandboxContext.jsx
+++ b/src/context/InstructorSandboxContext.jsx
@@ -624,7 +624,7 @@ export function InstructorSandboxProvider({ children }) {
       .filter(Boolean)
   }
 
-  const saveDeadline = async (courseId, assignmentId, userId, extendedDueDate) => {
+  const saveDeadline = async (courseId, assignmentId, userId, extendedDueDate, reason = null) => {
     setState((prev) => ({
       ...prev,
       deadlinesByCourse: {
@@ -637,11 +637,71 @@ export function InstructorSandboxProvider({ children }) {
               assignment_id: assignmentId,
               user_id: userId,
               extension_due_at: extendedDueDate,
+              reason: reason || null,
+              created_at: new Date().toISOString(),
             },
           },
         },
       },
     }))
+  }
+
+  const getAssignmentExtensions = async (assignmentId) => {
+    const courseId = courseState.activeCourseId
+    const students = (courseState.gradebookByCourse?.[courseId] || []).filter(
+      (student) => String(student.role || "student").toLowerCase() !== "ta"
+    )
+    const byUser = state.deadlinesByCourse?.[courseId] || {}
+    return students
+      .map((student) => {
+        const ext = byUser[student.id]?.[assignmentId]
+        if (!ext?.extension_due_at) return null
+        return {
+          id: `${student.id}-${assignmentId}`,
+          assignment_id: assignmentId,
+          user_id: student.id,
+          extended_due_date: ext.extension_due_at,
+          reason: ext.reason || null,
+          created_at: ext.created_at || null,
+          User: { id: student.id, username: student.username },
+        }
+      })
+      .filter(Boolean)
+  }
+
+  const saveClasswideExtension = async (assignmentId, { extendedDueDate, reason } = {}) => {
+    if (!extendedDueDate || Number.isNaN(Date.parse(extendedDueDate))) {
+      throw new Error("A valid extended due date is required.")
+    }
+    const courseId = courseState.activeCourseId
+    const students = (courseState.gradebookByCourse?.[courseId] || []).filter(
+      (student) => String(student.role || "student").toLowerCase() !== "ta"
+    )
+    const grantedAt = new Date().toISOString()
+    const trimmedReason = typeof reason === "string" ? reason.trim().slice(0, 500) : null
+    setState((prev) => {
+      const courseDeadlines = { ...(prev.deadlinesByCourse?.[courseId] || {}) }
+      for (const student of students) {
+        courseDeadlines[student.id] = {
+          ...(courseDeadlines[student.id] || {}),
+          [assignmentId]: {
+            assignment_id: assignmentId,
+            user_id: student.id,
+            extension_due_at: extendedDueDate,
+            reason: trimmedReason || null,
+            created_at: grantedAt,
+          },
+        }
+      }
+      return {
+        ...prev,
+        deadlinesByCourse: {
+          ...prev.deadlinesByCourse,
+          [courseId]: courseDeadlines,
+        },
+      }
+    })
+    return { updated: students.length }
   }
 
   const getActivity = (activityId) => {
@@ -729,6 +789,8 @@ export function InstructorSandboxProvider({ children }) {
     saveAccommodations,
     getDeadlines,
     saveDeadline,
+    getAssignmentExtensions,
+    saveClasswideExtension,
     getActivity,
     getQuestionState: (questionId) => state.questionStates?.[questionId] || null,
     isQuestionComplete: (questionId) => completedQuestionIds.has(questionId),

--- a/src/pages/instructor/InstructorAssignments.jsx
+++ b/src/pages/instructor/InstructorAssignments.jsx
@@ -289,7 +289,7 @@ export default function InstructorAssignments() {
         extendedDueDate: iso,
         reason: classwideForm.reason?.trim().slice(0, 500) || null,
       });
-      if (result?.updated === 0) {
+      if ((result?.total ?? 0) === 0) {
         setClasswideError("No enrolled students to extend.");
         return;
       }

--- a/src/pages/instructor/InstructorAssignments.jsx
+++ b/src/pages/instructor/InstructorAssignments.jsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useCallback, useState } from "react";
 import {
   Box,
   Typography,
@@ -18,7 +18,10 @@ import {
 import AssignmentTable from "../../components/ui/AssignmentTable";
 import AssignmentFormDialog from "../../components/ui/AssignmentFormDialog";
 import AssignmentContextMenu from "../../components/ui/AssignmentContextMenu";
+import ClasswideExtensionDialog from "../../components/ui/assignments/ClasswideExtensionDialog";
+import AssignmentExtensionsDialog from "../../components/ui/assignments/AssignmentExtensionsDialog";
 import { sortAssignmentsBySubchapter } from "../../utils/assignmentSort.js";
+import { toEasternIso } from "../../utils/easternTime.js";
 import {
   getStatusColor,
   getStatusText,
@@ -67,6 +70,16 @@ export default function InstructorAssignments() {
   const [dueDateDialogOpen, setDueDateDialogOpen] = useState(false);
   const [dueDateEditAssignment, setDueDateEditAssignment] = useState(null);
   const [dueDateForm, setDueDateForm] = useState({ dueDate: "", dueTime: "23:59" });
+  const [extensionAssignment, setExtensionAssignment] = useState(null);
+  const [classwideOpen, setClasswideOpen] = useState(false);
+  const [extensionsListOpen, setExtensionsListOpen] = useState(false);
+  const [classwideForm, setClasswideForm] = useState({
+    dueDate: "",
+    dueTime: "23:59",
+    reason: "",
+  });
+  const [classwideSaving, setClasswideSaving] = useState(false);
+  const [classwideError, setClasswideError] = useState("");
 
   // Get current course data
   const activeCourse = courses.find((c) => c.id === activeCourseId);
@@ -234,6 +247,61 @@ export default function InstructorAssignments() {
     }
   };
 
+  const loadAssignmentExtensions = useCallback(
+    (assignmentId) =>
+      courseActions.getAssignmentExtensions?.(assignmentId) ?? Promise.resolve([]),
+    [courseActions]
+  );
+
+  const handleOpenClasswideExtension = (assignment) => {
+    if (!assignment?.id) return;
+    setExtensionAssignment(assignment);
+    setClasswideForm({
+      dueDate: assignment.dueDate || getCurrentDate(),
+      dueTime: assignment.dueTime || "23:59",
+      reason: "",
+    });
+    setClasswideError("");
+    setClasswideOpen(true);
+  };
+
+  const handleOpenExtensionsList = (assignment) => {
+    if (!assignment?.id) return;
+    setExtensionAssignment(assignment);
+    setExtensionsListOpen(true);
+  };
+
+  const handleClasswideSubmit = async () => {
+    if (classwideSaving || !extensionAssignment?.id || !classwideForm.dueDate) return;
+    const iso = toEasternIso(classwideForm.dueDate, classwideForm.dueTime || "23:59");
+    if (!iso) {
+      setClasswideError("Choose a valid date and time.");
+      return;
+    }
+    if (typeof courseActions.saveClasswideExtension !== "function") {
+      setClasswideError("Classwide extensions are not available.");
+      return;
+    }
+    setClasswideSaving(true);
+    setClasswideError("");
+    try {
+      const result = await courseActions.saveClasswideExtension(extensionAssignment.id, {
+        extendedDueDate: iso,
+        reason: classwideForm.reason?.trim().slice(0, 500) || null,
+      });
+      if (result?.updated === 0) {
+        setClasswideError("No enrolled students to extend.");
+        return;
+      }
+      setClasswideOpen(false);
+      setExtensionsListOpen(true);
+    } catch (error) {
+      setClasswideError(error?.message || "Failed to apply classwide extension.");
+    } finally {
+      setClasswideSaving(false);
+    }
+  };
+
   // Show message if no active course
   if (!activeCourseId) {
     return (
@@ -309,6 +377,8 @@ export default function InstructorAssignments() {
         item={menuAssignment}
         onOpenBuilder={handleOpenBuilder}
         onEdit={handleEditOpen}
+        onClasswideExtension={handleOpenClasswideExtension}
+        onViewExtensions={handleOpenExtensionsList}
         onDuplicate={handleDuplicate}
         onDelete={handleDelete}
       />
@@ -396,6 +466,33 @@ export default function InstructorAssignments() {
           </Button>
         </DialogActions>
       </Dialog>
+      {/* Classwide extension */}
+      <ClasswideExtensionDialog
+        open={classwideOpen}
+        assignment={extensionAssignment}
+        form={classwideForm}
+        onChange={(patch) => setClasswideForm((prev) => ({ ...prev, ...patch }))}
+        onClose={() => {
+          if (classwideSaving) return;
+          setClasswideOpen(false);
+          setClasswideError("");
+        }}
+        onSubmit={handleClasswideSubmit}
+        saving={classwideSaving}
+        error={classwideError}
+      />
+
+      {/* Extension list */}
+      <AssignmentExtensionsDialog
+        open={extensionsListOpen}
+        assignment={extensionAssignment}
+        loadExtensions={loadAssignmentExtensions}
+        onClose={() => setExtensionsListOpen(false)}
+        onClasswide={() => {
+          setExtensionsListOpen(false);
+          if (extensionAssignment) handleOpenClasswideExtension(extensionAssignment);
+        }}
+      />
     </Box>
   );
 }

--- a/src/runtime/appRuntime.js
+++ b/src/runtime/appRuntime.js
@@ -256,6 +256,30 @@ export function createAppRuntime({ coursesDispatch, coursesState, routeKind, use
         }),
       });
     },
+    getAssignmentExtensions: async (assignmentId) => {
+      const id = Number(assignmentId);
+      if (!Number.isInteger(id) || id <= 0) return [];
+      const rows = await fetchJson(`/api/instructor/assignments/${id}/extensions`);
+      return Array.isArray(rows) ? rows : [];
+    },
+    saveClasswideExtension: async (assignmentId, { extendedDueDate, reason } = {}) => {
+      const id = Number(assignmentId);
+      if (!Number.isInteger(id) || id <= 0) {
+        throw new Error("A valid assignment is required.");
+      }
+      if (!extendedDueDate || Number.isNaN(Date.parse(extendedDueDate))) {
+        throw new Error("A valid extended due date is required.");
+      }
+      const trimmedReason = typeof reason === "string" ? reason.trim().slice(0, 500) : null;
+      return fetchJson(`/api/instructor/assignments/${id}/extensions/classwide`, {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          extended_due_date: extendedDueDate,
+          reason: trimmedReason || null,
+        }),
+      });
+    },
     loadInstructorDashboard: async (courseId) => {
       const [analytics, summary] = await Promise.all([
         fetchJson(`/api/analytics/instructor-dashboard?courseId=${courseId}`),


### PR DESCRIPTION
### Summary
Instructor UI for classwide extensions and a read-only extension list.

- Assignments ⋮ menu: **Classwide extension** and **View extensions**
- Classwide dialog: date/time, optional reason, overwrite warning
- Read-only table of who has an extension, until when, and who granted it
- Wired in the live app (`PUT`) and instructor sandbox

### Test
1. Instructor → **Assignments** → ⋮ on an assignment.
2. **View extensions** -- empty state if none.
3. **Classwide extension** -- set date/time, apply. Table should fill with one row per student.
4. Confirm a later classwide grant overwrites a per-student extension.
5. Optional: `/sandbox/instructor` -- same menu (sandbox roster only).