### PR TITLE
Fitch rulebook

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -24,6 +24,7 @@
         "framer-motion": "^12.38.0",
         "jspdf": "^3.0.3",
         "lucide-react": "^0.562.0",
+        "mathjax": "^3.2.2",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
         "react-router-dom": "^7.11.0",
@@ -3391,6 +3392,12 @@
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.5"
       }
+    },
+    "node_modules/mathjax": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/mathjax/-/mathjax-3.2.2.tgz",
+      "integrity": "sha512-Bt+SSVU8eBG27zChVewOicYs7Xsdt40qm4+UpHyX7k0/O9NliPc+x77k1/FEsPsjKPZGJvtRZM1vO+geW0OhGw==",
+      "license": "Apache-2.0"
     },
     "node_modules/motion-dom": {
       "version": "12.38.0",

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "framer-motion": "^12.38.0",
     "jspdf": "^3.0.3",
     "lucide-react": "^0.562.0",
+    "mathjax": "^3.2.2",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "react-router-dom": "^7.11.0",

--- a/src/components/layout/Header.jsx
+++ b/src/components/layout/Header.jsx
@@ -122,6 +122,7 @@ export default function Header({ onSignOut }) {
         </Box>
         <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
           <Button
+            id="rules-reference-trigger"
             onClick={() => {
               if (isRulesReferenceOpen) {
                 closeRulesReference(layoutDispatch);
@@ -130,7 +131,8 @@ export default function Header({ onSignOut }) {
               openRulesReference(layoutDispatch);
             }}
             startIcon={<MenuBookIcon />}
-            aria-pressed={isRulesReferenceOpen}
+            aria-expanded={isRulesReferenceOpen}
+            aria-controls="rules-reference"
             sx={{ 
               textTransform: 'none',
               color: 'primary.main',

--- a/src/components/problems/derivation/DerivationFormulaCell.jsx
+++ b/src/components/problems/derivation/DerivationFormulaCell.jsx
@@ -128,7 +128,7 @@ export default function DerivationFormulaCell({
           inputRef={registerInput}
           onCursorChange={onMobileCursorChange}
           includeQuantifiers={keyboardConfig.isPredicateMode}
-          extraInsertButtons={keyboardConfig.extraQuantifierButtons}
+          extraInsertButtons={keyboardConfig.extraSymbolButtons}
           predicateLetters={keyboardConfig.isPredicateMode ? keyboardConfig.predicateLetters : undefined}
           constantLetters={keyboardConfig.isPredicateMode ? keyboardConfig.constantLetters : undefined}
           variableLetters={keyboardConfig.isPredicateMode ? keyboardConfig.variableLetters : undefined}

--- a/src/components/problems/derivation/DerivationTable.jsx
+++ b/src/components/problems/derivation/DerivationTable.jsx
@@ -227,11 +227,11 @@ export default function DerivationTable({
     const premises = Array.isArray(proof?.premises) ? proof.premises : []
     const conclusion = proof?.conclusion ?? proof?.conc ?? ''
     const formulaText = [...premises, conclusion].filter(Boolean).map(String).join(' ')
-    const extraQuantifierButtons = getQuantifierButtonsFromFormulas(
-      premises,
-      conclusion,
-      syntax
-    )
+    const extraSymbolButtons = [
+      { label: symbols.falsum, insert: symbols.falsum },
+      ...(allowIndexedSymbols ? [{ label: 'x₂', insert: '_' }] : []),
+      ...getQuantifierButtonsFromFormulas(premises, conclusion, syntax),
+    ]
 
     const isPredicate = isPredicateLogicKey(key, allowIndexedSymbols) || /[∀∃]/.test(formulaText) || /[A-Z][a-z]/.test(formulaText) || /[A-Z](?:_[1-9][0-9]*|[₁-₉][₀-₉]*)?\s*\(/.test(formulaText)
 
@@ -257,7 +257,7 @@ export default function DerivationTable({
         predicateLetters,
         constantLetters,
         variableLetters,
-        extraQuantifierButtons,
+        extraSymbolButtons,
       }
     }
 
@@ -270,19 +270,19 @@ export default function DerivationTable({
     return {
       isPredicateMode: false,
       symbolizationKey: predicateLetters,
-      extraQuantifierButtons,
+      extraSymbolButtons,
     }
-  }, [allowIndexedSymbols, proof, syntax])
+  }, [allowIndexedSymbols, proof, symbols.falsum, syntax])
   const symbolButtons = useMemo(() => {
     const baseSymbolButtons = getSymbolButtons(symbols, syntax)
-    const extraQuantifierButtons = derivationKeyboardConfig.extraQuantifierButtons || []
-    if (extraQuantifierButtons.length === 0) return baseSymbolButtons
+    const extraSymbolButtons = derivationKeyboardConfig.extraSymbolButtons || []
+    if (extraSymbolButtons.length === 0) return baseSymbolButtons
     return [
       ...baseSymbolButtons.slice(0, 7),
-      ...extraQuantifierButtons,
+      ...extraSymbolButtons,
       ...baseSymbolButtons.slice(7),
     ]
-  }, [derivationKeyboardConfig.extraQuantifierButtons, symbols, syntax])
+  }, [derivationKeyboardConfig.extraSymbolButtons, symbols, syntax])
   const isLineCompleteForCheck = useCallback((line) => {
     if (!line) return false
     const formulaFilled = (line.formula || '').trim().length > 0

--- a/src/components/ui/MathJaxFormula.jsx
+++ b/src/components/ui/MathJaxFormula.jsx
@@ -1,0 +1,55 @@
+import { useEffect, useRef, useState } from 'react'
+import mathJaxUrl from 'mathjax/es5/tex-svg.js?url'
+
+let mathJaxReady
+let typesetQueue = Promise.resolve()
+
+function loadMathJax() {
+  if (window.MathJax?.typesetPromise) return Promise.resolve(window.MathJax)
+  if (mathJaxReady) return mathJaxReady
+
+  window.MathJax = {
+    options: { enableMenu: false },
+    svg: { fontCache: 'local' },
+    startup: { typeset: false },
+  }
+  mathJaxReady = new Promise((resolve, reject) => {
+    const script = document.createElement('script')
+    script.src = mathJaxUrl
+    script.async = true
+    script.onload = () => window.MathJax.startup.promise.then(() => resolve(window.MathJax), reject)
+    script.onerror = () => reject(new Error('MathJax failed to load'))
+    document.head.appendChild(script)
+  })
+  return mathJaxReady
+}
+
+export default function MathJaxFormula({ tex, fallback }) {
+  const containerRef = useRef(null)
+  const [ready, setReady] = useState(Boolean(window.MathJax?.typesetPromise))
+
+  useEffect(() => {
+    let cancelled = false
+    loadMathJax().then(() => {
+      if (!cancelled) setReady(true)
+    }).catch(() => {})
+    return () => { cancelled = true }
+  }, [])
+
+  useEffect(() => {
+    if (!ready || !containerRef.current) return undefined
+    const element = containerRef.current
+    let cancelled = false
+    typesetQueue = typesetQueue.catch(() => {}).then(async () => {
+      if (cancelled || !element.isConnected) return
+      window.MathJax.typesetClear?.([element])
+      element.textContent = `\\[${tex}\\]`
+      await window.MathJax.typesetPromise([element])
+    }).catch(() => {
+      if (!cancelled && element.isConnected) element.textContent = fallback
+    })
+    return () => { cancelled = true }
+  }, [fallback, ready, tex])
+
+  return <span ref={containerRef} aria-label={fallback}>{fallback}</span>
+}

--- a/src/components/ui/RulesReference.jsx
+++ b/src/components/ui/RulesReference.jsx
@@ -1,5 +1,6 @@
-import { useId, useState } from 'react'
+import { useCallback, useEffect, useId, useState } from 'react'
 import { Box, Typography, IconButton, Drawer, alpha, useMediaQuery, useTheme } from '@mui/material'
+import CloseIcon from '@mui/icons-material/Close'
 import ExpandMoreIcon from '@mui/icons-material/ExpandMore'
 import ExpandLessIcon from '@mui/icons-material/ExpandLess'
 import { useLayoutState, useLayoutDispatch, closeRulesReference } from '../../context/LayoutContext.jsx'
@@ -296,17 +297,25 @@ export default function RulesReference({ logicSystem }) {
       : []),
   ]
   
-  const blurActiveElement = () => {
-    const el = document.activeElement
-    if (el && typeof el.blur === 'function') {
-      el.blur()
-    }
-  }
-
-  const handleClose = () => {
+  const handleClose = useCallback(() => {
     closeRulesReference(dispatch)
-    blurActiveElement()
-  }
+    window.requestAnimationFrame(() => {
+      document.getElementById('rules-reference-trigger')?.focus()
+    })
+  }, [dispatch])
+
+  useEffect(() => {
+    if (!isDesktop || !isRulesReferenceOpen) return undefined
+
+    const handleKeyDown = (event) => {
+      if (event.key !== 'Escape') return
+      event.preventDefault()
+      handleClose()
+    }
+
+    document.addEventListener('keydown', handleKeyDown)
+    return () => document.removeEventListener('keydown', handleKeyDown)
+  }, [handleClose, isDesktop, isRulesReferenceOpen])
   
   const rulesContent = (
     <Box
@@ -439,8 +448,8 @@ export default function RulesReference({ logicSystem }) {
           {isFitch ? 'Fitch rules & shortcuts' : 'Hurley rules & shortcuts'}
         </Typography>
       </Box>
-      <IconButton onClick={handleClose}>
-        <ExpandLessIcon />
+      <IconButton onClick={handleClose} aria-label="Close rulebook">
+        <CloseIcon />
       </IconButton>
     </Box>
   )
@@ -448,6 +457,9 @@ export default function RulesReference({ logicSystem }) {
   if (isDesktop) {
     return (
       <Box
+        component="aside"
+        id="rules-reference"
+        aria-label="Rulebook"
         sx={{
           width: isRulesReferenceOpen ? 'clamp(480px, 40vw, 680px)' : 0,
           maxWidth: isRulesReferenceOpen ? 'min(680px, 48vw)' : 0,
@@ -484,6 +496,12 @@ export default function RulesReference({ logicSystem }) {
       onClose={handleClose}
       ModalProps={{
         keepMounted: true,
+      }}
+      slotProps={{
+        paper: {
+          id: 'rules-reference',
+          'aria-label': 'Rulebook',
+        },
       }}
       sx={{
         display: 'block',

--- a/src/components/ui/RulesReference.jsx
+++ b/src/components/ui/RulesReference.jsx
@@ -43,7 +43,7 @@ function RulesCard({ title, children, defaultExpanded = false }) {
           sx={{ 
             color: 'inherit',
             fontWeight: expanded ? 600 : 400,
-            fontSize: '0.9rem',
+            fontSize: '1rem',
           }}
         >
           {title}
@@ -66,7 +66,7 @@ function RulesCard({ title, children, defaultExpanded = false }) {
       {expanded && (
         <Box 
           sx={{ 
-            fontSize: '0.9rem', 
+            fontSize: '1rem',
             lineHeight: 1.5, 
             color: 'text.primary',
             padding: '8px 12px',
@@ -96,10 +96,10 @@ function FitchRuleEntries({ group }) {
       component="section"
       sx={{ px: 0.5, py: 1.25, borderBottom: 1, borderColor: 'divider' }}
     >
-      <Typography component="h4" sx={{ m: 0, fontSize: '0.85rem', fontWeight: 700 }}>
+      <Typography component="h4" sx={{ m: 0, fontSize: '1rem', fontWeight: 700 }}>
         {group.start + index}. {rule.title} ({rule.name})
       </Typography>
-      <Typography component="div" sx={{ mt: 0.6, fontSize: '0.8rem', color: 'text.primary' }}>
+      <Typography component="div" sx={{ mt: 0.6, fontSize: '1rem', color: 'text.primary' }}>
         <EmphasizedText text={rule.description} bold={rule.bold} />
       </Typography>
       {(FITCH_RULE_EXAMPLES[rule.name] || []).map((example, exampleIndex) => (
@@ -126,13 +126,13 @@ function FitchRuleEntries({ group }) {
         </Box>
       ))}
       {rule.note && (
-        <Typography component="div" sx={{ mt: 0.6, fontSize: '0.78rem', color: 'text.secondary' }}>
+        <Typography component="div" sx={{ mt: 0.6, fontSize: '1rem', color: 'text.secondary' }}>
           {rule.noteLabelBold ? <strong>Note:</strong> : 'Note:'}{' '}
           <EmphasizedText text={rule.note} bold={rule.noteBold} />
         </Typography>
       )}
       {rule.notes?.map((note) => (
-        <Typography key={note.text} component="div" sx={{ mt: 0.6, fontSize: '0.78rem', color: 'text.secondary' }}>
+        <Typography key={note.text} component="div" sx={{ mt: 0.6, fontSize: '1rem', color: 'text.secondary' }}>
           {note.labelBold ? <strong>Note:</strong> : 'Note:'}{' '}
           <EmphasizedText text={note.text} bold={note.bold} />
         </Typography>
@@ -172,7 +172,7 @@ function FitchRuleGroup({ group }) {
           '&:hover': { bgcolor: (t) => alpha(t.palette.primary.main, 0.1) },
         }}
       >
-        <Typography component="span" sx={{ fontWeight: 700, fontSize: '0.95rem' }}>
+        <Typography component="span" sx={{ fontWeight: 700, fontSize: '1rem' }}>
           {group.title}
         </Typography>
         {expanded ? <ExpandLessIcon fontSize="small" /> : <ExpandMoreIcon fontSize="small" />}
@@ -234,7 +234,7 @@ function ShortcutTable({ rows }) {
                       bgcolor: 'transparent',
                       color: 'text.primary',
                       fontFamily: 'monospace',
-                      fontSize: '0.75rem',
+                      fontSize: '0.875rem',
                       lineHeight: 1.4,
                       textAlign: 'center',
                     }}
@@ -244,7 +244,7 @@ function ShortcutTable({ rows }) {
                 ))}
               </Box>
             </Box>
-            <Box component="td" sx={{ py: 0.75, color: 'text.secondary', fontSize: '0.8rem' }}>
+            <Box component="td" sx={{ py: 0.75, color: 'text.secondary', fontSize: '1rem' }}>
               {meaning}
             </Box>
           </Box>
@@ -302,10 +302,10 @@ export default function RulesReference({ logicSystem }) {
     >
       <RulesCard title="Keyboard Shortcuts" defaultExpanded={true}>
         <ShortcutTable rows={shortcutRows} />
-        <Typography variant="subtitle2" sx={{ fontWeight: 700, mb: 0.5, color: 'primary.main', fontSize: '0.95rem' }}>
+        <Typography variant="subtitle2" sx={{ fontWeight: 700, mb: 0.5, color: 'primary.main', fontSize: '1rem' }}>
           Navigation
         </Typography>
-        <Box component="div" sx={{ fontSize: '0.85rem' }}>
+        <Box component="div" sx={{ fontSize: '1rem' }}>
           <div><strong>•</strong> Press <strong>Enter</strong> to go to the justification line</div>
         </Box>
       </RulesCard>
@@ -314,9 +314,9 @@ export default function RulesReference({ logicSystem }) {
         {isFitch ? (
           <>
             <Box sx={{ mb: 2, p: 1, borderRadius: 1, bgcolor: (t) => alpha(t.palette.primary.main, 0.06) }}>
-              <Typography component="div" sx={{ mb: 0.75, fontSize: '0.85rem', fontWeight: 700 }}>Definitions</Typography>
+              <Typography component="div" sx={{ mb: 0.75, fontSize: '1rem', fontWeight: 700 }}>Definitions</Typography>
               {FITCH_DEFINITIONS.map((definition) => (
-                <Typography key={definition.text} component="p" sx={{ m: 0, '&:not(:last-child)': { mb: 1 }, fontSize: '0.8rem', color: 'text.primary' }}>
+                <Typography key={definition.text} component="p" sx={{ m: 0, '&:not(:last-child)': { mb: 1 }, fontSize: '1rem', color: 'text.primary' }}>
                   <EmphasizedText text={definition.text} bold={definition.bold} />
                 </Typography>
               ))}
@@ -325,10 +325,10 @@ export default function RulesReference({ logicSystem }) {
           </>
         ) : (
           <>
-            <Typography variant="subtitle2" sx={{ fontWeight: 700, mb: 0.5, color: 'primary.main', fontSize: '0.95rem' }}>
+            <Typography variant="subtitle2" sx={{ fontWeight: 700, mb: 0.5, color: 'primary.main', fontSize: '1rem' }}>
               Rules of Implication
             </Typography>
-            <Box component="div" sx={{ mb: 1.5, fontSize: '0.85rem' }}>
+            <Box component="div" sx={{ mb: 1.5, fontSize: '1rem' }}>
               <div><strong>1. MP:</strong> p ⊃ q, p / q</div>
               <div><strong>2. MT:</strong> p ⊃ q, ~q / ~p</div>
               <div><strong>3. HS:</strong> p ⊃ q, q ⊃ r / p ⊃ r</div>
@@ -338,10 +338,10 @@ export default function RulesReference({ logicSystem }) {
               <div><strong>7. Conj:</strong> p, q / p • q</div>
               <div><strong>8. Add:</strong> p / p ∨ q</div>
             </Box>
-            <Typography variant="subtitle2" sx={{ fontWeight: 700, mb: 0.5, color: 'primary.main', fontSize: '0.95rem' }}>
+            <Typography variant="subtitle2" sx={{ fontWeight: 700, mb: 0.5, color: 'primary.main', fontSize: '1rem' }}>
               Rules of Replacement
             </Typography>
-            <Box component="div" sx={{ fontSize: '0.85rem' }}>
+            <Box component="div" sx={{ fontSize: '1rem' }}>
               <div><strong>9. DM:</strong></div>
               <div style={{ paddingLeft: '28px' }}>~(p • q) :: (~p ∨ ~q)</div>
               <div style={{ paddingLeft: '28px' }}>~(p ∨ q) :: (~p • ~q)</div>
@@ -375,7 +375,7 @@ export default function RulesReference({ logicSystem }) {
       
       <RulesCard title={isFitch ? 'Natural Deduction Rules for FOL' : 'Predicate Logic Rules'} defaultExpanded={false}>
         {!isFitch && (
-          <Typography variant="subtitle2" sx={{ fontWeight: 700, mb: 0.5, color: 'primary.main', fontSize: '0.95rem' }}>
+          <Typography variant="subtitle2" sx={{ fontWeight: 700, mb: 0.5, color: 'primary.main', fontSize: '1rem' }}>
             Predicate Logic Rules
           </Typography>
         )}
@@ -383,16 +383,16 @@ export default function RulesReference({ logicSystem }) {
           <FitchRuleGroups groups={FITCH_FOL_RULE_GROUPS} />
         ) : (
           <>
-            <Box component="div" sx={{ mb: 1.5, fontSize: '0.85rem' }}>
+            <Box component="div" sx={{ mb: 1.5, fontSize: '1rem' }}>
               <div><strong>UI:</strong> (x)Fx / Fx &nbsp;or&nbsp; (x)Fx / Fa</div>
               <div><strong>UG:</strong> Fx / (x)Fx</div>
               <div><strong>EI:</strong> (∃x)Fx / Fa</div>
               <div><strong>EG:</strong> Fa / (∃x)Fx &nbsp;or&nbsp; Fx / (∃x)Fx</div>
             </Box>
-            <Typography variant="subtitle2" sx={{ fontWeight: 700, mb: 0.5, color: 'primary.main', fontSize: '0.95rem' }}>
+            <Typography variant="subtitle2" sx={{ fontWeight: 700, mb: 0.5, color: 'primary.main', fontSize: '1rem' }}>
               Quantifier Negation (QN)
             </Typography>
-            <Box component="div" sx={{ mb: 1.5, fontSize: '0.85rem' }}>
+            <Box component="div" sx={{ mb: 1.5, fontSize: '1rem' }}>
               <div><strong>QN:</strong> ~(x)Fx :: (∃x)~Fx</div>
               <div><strong>QN:</strong> ~(∃x)Fx :: (x)~Fx</div>
               <div><strong>QN:</strong> (x)Fx :: ~(∃x)~Fx</div>
@@ -404,7 +404,7 @@ export default function RulesReference({ logicSystem }) {
 
       {!isFitch && (
         <RulesCard title="Conditional & Indirect Proofs" defaultExpanded={false}>
-          <Box component="div" sx={{ fontSize: '0.85rem' }}>
+          <Box component="div" sx={{ fontSize: '1rem' }}>
             <div><strong>ACP:</strong> Assumption for Conditional Proof</div>
             <div><strong>CP:</strong> To prove p ⊃ q, assume p (ACP) in an indented subderivation, derive q, then discharge with CP citing the subderivation range</div>
             <div><strong>AIP:</strong> Assumption for Indirect Proof</div>
@@ -433,8 +433,8 @@ export default function RulesReference({ logicSystem }) {
     return (
       <Box
         sx={{
-          width: isRulesReferenceOpen ? 'clamp(380px, 32vw, 520px)' : 0,
-          maxWidth: isRulesReferenceOpen ? 'min(520px, 40vw)' : 0,
+          width: isRulesReferenceOpen ? 'clamp(480px, 40vw, 680px)' : 0,
+          maxWidth: isRulesReferenceOpen ? 'min(680px, 48vw)' : 0,
           minWidth: 0,
           flexShrink: 0,
           overflow: 'hidden',
@@ -472,8 +472,8 @@ export default function RulesReference({ logicSystem }) {
       sx={{
         display: 'block',
         '& .MuiDrawer-paper': {
-          width: { xs: '92%', sm: '480px' },
-          maxWidth: 'min(480px, 92vw)',
+          width: { xs: '92%', sm: '560px' },
+          maxWidth: 'min(560px, 92vw)',
         },
       }}
     >

--- a/src/components/ui/RulesReference.jsx
+++ b/src/components/ui/RulesReference.jsx
@@ -331,7 +331,7 @@ export default function RulesReference({ logicSystem }) {
           Navigation
         </Typography>
         <Box component="div" sx={{ fontSize: '1rem' }}>
-          <div><strong>•</strong> Press <strong>Enter</strong> to go to the justification line</div>
+          <div><strong>•</strong> Press <strong>Enter</strong> or the <strong>greater-than key</strong> to go to the rule justification line</div>
         </Box>
       </RulesCard>
       

--- a/src/components/ui/RulesReference.jsx
+++ b/src/components/ui/RulesReference.jsx
@@ -1,4 +1,4 @@
-import { useState } from 'react'
+import { useId, useState } from 'react'
 import { Box, Typography, IconButton, Drawer, alpha, useMediaQuery, useTheme } from '@mui/material'
 import ExpandMoreIcon from '@mui/icons-material/ExpandMore'
 import ExpandLessIcon from '@mui/icons-material/ExpandLess'
@@ -14,33 +14,46 @@ import MathJaxFormula from './MathJaxFormula.jsx'
 
 function RulesCard({ title, children, defaultExpanded = false }) {
   const [expanded, setExpanded] = useState(defaultExpanded)
+  const accordionId = useId()
+  const triggerId = `${accordionId}-trigger`
+  const contentId = `${accordionId}-content`
 
   return (
+    <Box sx={{ width: '100%', mb: 1 }}>
       <Box
+        component="button"
+        type="button"
+        id={triggerId}
+        aria-expanded={expanded}
+        aria-controls={contentId}
+        onClick={() => setExpanded((current) => !current)}
         sx={{
           width: '100%',
-          mb: 1,
-        }}
-      >
-        <Box 
-        onClick={() => setExpanded(!expanded)}
-        sx={{ 
-          display: 'flex', 
-          alignItems: 'center', 
+          border: 0,
+          bgcolor: 'transparent',
+          font: 'inherit',
+          display: 'flex',
+          alignItems: 'center',
           justifyContent: 'space-between',
           padding: '10px 12px',
           color: 'primary.main',
+          textAlign: 'left',
           cursor: 'pointer',
-          transition: 'all 0.2s ease',
+          transition: 'color 0.2s ease, background-color 0.2s ease',
           '&:hover': {
             color: 'primary.main',
             backgroundColor: (theme) => alpha(theme.palette.primary.main, 0.08),
           },
+          '&:focus-visible': {
+            outline: '2px solid',
+            outlineColor: 'primary.main',
+            outlineOffset: '-2px',
+          },
         }}
       >
-        <Typography 
-          variant="body1" 
-          sx={{ 
+        <Typography
+          component="span"
+          sx={{
             color: 'inherit',
             fontWeight: expanded ? 600 : 400,
             fontSize: '1rem',
@@ -48,26 +61,18 @@ function RulesCard({ title, children, defaultExpanded = false }) {
         >
           {title}
         </Typography>
-        <IconButton
-          size="small"
-          onClick={(e) => {
-            e.stopPropagation()
-            setExpanded(!expanded)
-          }}
-          sx={{ 
-            color: 'inherit',
-            padding: '4px',
-            '&:hover': { backgroundColor: 'transparent' }
-          }}
-        >
-          {expanded ? <ExpandLessIcon fontSize="small" /> : <ExpandMoreIcon fontSize="small" />}
-        </IconButton>
+        {expanded
+          ? <ExpandLessIcon aria-hidden="true" fontSize="small" />
+          : <ExpandMoreIcon aria-hidden="true" fontSize="small" />}
       </Box>
       {expanded && (
-        <Box 
-          sx={{ 
+        <Box
+          id={contentId}
+          role="region"
+          aria-labelledby={triggerId}
+          sx={{
             fontSize: '1rem',
-            lineHeight: 1.5, 
+            lineHeight: 1.5,
             color: 'text.primary',
             padding: '8px 12px',
             paddingTop: '6px',
@@ -143,6 +148,9 @@ function FitchRuleEntries({ group }) {
 
 function FitchRuleGroup({ group }) {
   const [expanded, setExpanded] = useState(true)
+  const accordionId = useId()
+  const triggerId = `${accordionId}-trigger`
+  const contentId = `${accordionId}-content`
 
   if (!group.title) {
     return <FitchRuleEntries group={group} />
@@ -153,7 +161,9 @@ function FitchRuleGroup({ group }) {
       <Box
         component="button"
         type="button"
+        id={triggerId}
         aria-expanded={expanded}
+        aria-controls={contentId}
         onClick={() => setExpanded((current) => !current)}
         sx={{
           width: '100%',
@@ -175,9 +185,15 @@ function FitchRuleGroup({ group }) {
         <Typography component="span" sx={{ fontWeight: 700, fontSize: '1rem' }}>
           {group.title}
         </Typography>
-        {expanded ? <ExpandLessIcon fontSize="small" /> : <ExpandMoreIcon fontSize="small" />}
+        {expanded
+          ? <ExpandLessIcon aria-hidden="true" fontSize="small" />
+          : <ExpandMoreIcon aria-hidden="true" fontSize="small" />}
       </Box>
-      {expanded && <FitchRuleEntries group={group} />}
+      {expanded && (
+        <Box id={contentId} role="region" aria-labelledby={triggerId}>
+          <FitchRuleEntries group={group} />
+        </Box>
+      )}
     </Box>
   )
 }

--- a/src/components/ui/RulesReference.jsx
+++ b/src/components/ui/RulesReference.jsx
@@ -188,6 +188,72 @@ function FitchRuleGroups({ groups }) {
   ))
 }
 
+function ShortcutTable({ rows }) {
+  const headerSx = {
+    pb: 0.6,
+    color: 'text.secondary',
+    fontSize: '0.68rem',
+    fontWeight: 700,
+    letterSpacing: '0.06em',
+    textAlign: 'left',
+    textTransform: 'uppercase',
+  }
+
+  return (
+    <Box component="table" sx={{ width: '100%', mb: 1.5, borderCollapse: 'collapse', tableLayout: 'fixed' }}>
+      <Box component="thead">
+        <Box component="tr">
+          <Box component="th" sx={headerSx}>Symbol</Box>
+          <Box component="th" sx={headerSx}>Shortcut</Box>
+          <Box component="th" sx={headerSx}>Meaning</Box>
+        </Box>
+      </Box>
+      <Box component="tbody">
+        {rows.map(({ symbol, shortcuts, meaning }) => (
+          <Box component="tr" key={`${symbol}-${meaning}`}>
+            <Box
+              component="th"
+              scope="row"
+              sx={{ py: 0.75, pr: 1, fontSize: '1rem', fontWeight: 600, textAlign: 'left' }}
+            >
+              {symbol}
+            </Box>
+            <Box component="td" sx={{ py: 0.75, pr: 1 }}>
+              <Box sx={{ display: 'flex', gap: 0.5, flexWrap: 'wrap' }}>
+                {shortcuts.map((shortcut) => (
+                  <Box
+                    component="kbd"
+                    key={shortcut}
+                    sx={{
+                      minWidth: '1.6rem',
+                      px: 0.5,
+                      py: 0.1,
+                      border: 1,
+                      borderColor: 'divider',
+                      borderRadius: 0.75,
+                      bgcolor: 'transparent',
+                      color: 'text.primary',
+                      fontFamily: 'monospace',
+                      fontSize: '0.75rem',
+                      lineHeight: 1.4,
+                      textAlign: 'center',
+                    }}
+                  >
+                    {shortcut}
+                  </Box>
+                ))}
+              </Box>
+            </Box>
+            <Box component="td" sx={{ py: 0.75, color: 'text.secondary', fontSize: '0.8rem' }}>
+              {meaning}
+            </Box>
+          </Box>
+        ))}
+      </Box>
+    </Box>
+  )
+}
+
 export default function RulesReference({ logicSystem }) {
   const { isRulesReferenceOpen } = useLayoutState()
   const dispatch = useLayoutDispatch()
@@ -198,6 +264,21 @@ export default function RulesReference({ logicSystem }) {
   const activeLogicSystem = normalizeLogicSystem(logicSystem)
   const symbols = getSymbols(activeLogicSystem)
   const isFitch = activeLogicSystem === 'fitch'
+  const shortcutRows = [
+    { symbol: symbols.and, shortcuts: ['&', '^'], meaning: 'Conjunction' },
+    { symbol: symbols.or, shortcuts: ['v', '\\/'], meaning: 'Disjunction' },
+    { symbol: symbols.conditional, shortcuts: ['>', '->', '-->'], meaning: 'Conditional' },
+    { symbol: symbols.biconditional, shortcuts: ['==', '<->'], meaning: 'Biconditional' },
+    { symbol: symbols.not, shortcuts: ['~', '!'], meaning: 'Negation' },
+    { symbol: symbols.forall, shortcuts: ['all'], meaning: 'Universal quantifier' },
+    { symbol: symbols.exists, shortcuts: ['some'], meaning: 'Existential quantifier' },
+    ...(symbols.falsum
+      ? [{ symbol: symbols.falsum, shortcuts: ['#', 'XX'], meaning: 'Contradiction' }]
+      : []),
+    ...(isFitch
+      ? [{ symbol: 'x₂', shortcuts: ['_'], meaning: 'Numeric subscript' }]
+      : []),
+  ]
   
   const blurActiveElement = () => {
     const el = document.activeElement
@@ -220,21 +301,7 @@ export default function RulesReference({ logicSystem }) {
       }}
     >
       <RulesCard title="Keyboard Shortcuts" defaultExpanded={true}>
-        <Typography variant="subtitle2" sx={{ fontWeight: 700, mb: 0.5, color: 'primary.main', fontSize: '0.95rem' }}>
-          Symbols
-        </Typography>
-        <Box component="div" sx={{ mb: 1.5, fontSize: '0.85rem' }}>
-          <div><strong>{symbols.and}</strong> Type <strong>&</strong> or <strong>^</strong> for {symbols.and} (conjunction)</div>
-          <div><strong>{symbols.or}</strong> Type <strong>v</strong> or <strong>\/</strong> for {symbols.or} (disjunction)</div>
-          <div><strong>{symbols.conditional}</strong> Type <strong>{'>'}</strong>, <strong>-&gt;</strong>, or <strong>--&gt;</strong> for {symbols.conditional} (conditional)</div>
-          <div><strong>{symbols.biconditional}</strong> Type <strong>==</strong> or <strong>&lt;-&gt;</strong> for {symbols.biconditional} (biconditional)</div>
-          <div><strong>{symbols.not}</strong> Type <strong>~</strong> or <strong>!</strong> for {symbols.not} (negation)</div>
-          <div><strong>{symbols.forall}</strong> Type <strong>all</strong> for {symbols.forall} (universal quantifier)</div>
-          <div><strong>{symbols.exists}</strong> Type <strong>some</strong> for {symbols.exists} (existential quantifier)</div>
-          {symbols.falsum && (
-            <div><strong>{symbols.falsum}</strong> Type <strong>#</strong>, <strong>_</strong>, or <strong>XX</strong> for {symbols.falsum} (contradiction)</div>
-          )}
-        </Box>
+        <ShortcutTable rows={shortcutRows} />
         <Typography variant="subtitle2" sx={{ fontWeight: 700, mb: 0.5, color: 'primary.main', fontSize: '0.95rem' }}>
           Navigation
         </Typography>

--- a/src/components/ui/RulesReference.jsx
+++ b/src/components/ui/RulesReference.jsx
@@ -4,6 +4,13 @@ import ExpandMoreIcon from '@mui/icons-material/ExpandMore'
 import ExpandLessIcon from '@mui/icons-material/ExpandLess'
 import { useLayoutState, useLayoutDispatch, closeRulesReference } from '../../context/LayoutContext.jsx'
 import { getSymbols, normalizeLogicSystem } from '../../lib/logicSystems.js'
+import {
+  FITCH_DEFINITIONS,
+  FITCH_FOL_RULE_GROUPS,
+  FITCH_TFL_RULE_GROUPS,
+} from '../../lib/fitchRulebook.js'
+import { FITCH_RULE_EXAMPLES } from '../../lib/fitchRuleExamples.js'
+import MathJaxFormula from './MathJaxFormula.jsx'
 
 function RulesCard({ title, children, defaultExpanded = false }) {
   const [expanded, setExpanded] = useState(defaultExpanded)
@@ -73,6 +80,114 @@ function RulesCard({ title, children, defaultExpanded = false }) {
   )
 }
 
+function EmphasizedText({ text, bold = [] }) {
+  if (!bold.length) return text
+  const escaped = bold.map((term) => term.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'))
+  const parts = text.split(new RegExp(`(${escaped.join('|')})`, 'g'))
+  return parts.map((part, index) => (
+    bold.includes(part) ? <strong key={`${part}-${index}`}>{part}</strong> : part
+  ))
+}
+
+function FitchRuleEntries({ group }) {
+  return group.rules.map((rule, index) => (
+    <Box
+      key={rule.name}
+      component="section"
+      sx={{ px: 0.5, py: 1.25, borderBottom: 1, borderColor: 'divider' }}
+    >
+      <Typography component="h4" sx={{ m: 0, fontSize: '0.85rem', fontWeight: 700 }}>
+        {group.start + index}. {rule.title} ({rule.name})
+      </Typography>
+      <Typography component="div" sx={{ mt: 0.6, fontSize: '0.8rem', color: 'text.primary' }}>
+        <EmphasizedText text={rule.description} bold={rule.bold} />
+      </Typography>
+      {(FITCH_RULE_EXAMPLES[rule.name] || []).map((example, exampleIndex) => (
+        <Box
+          key={`${rule.name}-${exampleIndex}`}
+          sx={{
+            width: '100%',
+            my: 1,
+            px: 1,
+            py: 0.75,
+            minHeight: 44,
+            overflowX: 'auto',
+            textAlign: 'center',
+            borderRadius: 1,
+            bgcolor: (t) => alpha(t.palette.text.primary, 0.035),
+            '& mjx-container': { m: '0 !important' },
+          }}
+        >
+          <MathJaxFormula
+            key={example}
+            tex={example}
+            fallback={`${rule.title} (${rule.name}) proof example${FITCH_RULE_EXAMPLES[rule.name].length > 1 ? ` ${exampleIndex + 1}` : ''}`}
+          />
+        </Box>
+      ))}
+      {rule.note && (
+        <Typography component="div" sx={{ mt: 0.6, fontSize: '0.78rem', color: 'text.secondary' }}>
+          {rule.noteLabelBold ? <strong>Note:</strong> : 'Note:'}{' '}
+          <EmphasizedText text={rule.note} bold={rule.noteBold} />
+        </Typography>
+      )}
+      {rule.notes?.map((note) => (
+        <Typography key={note.text} component="div" sx={{ mt: 0.6, fontSize: '0.78rem', color: 'text.secondary' }}>
+          {note.labelBold ? <strong>Note:</strong> : 'Note:'}{' '}
+          <EmphasizedText text={note.text} bold={note.bold} />
+        </Typography>
+      ))}
+    </Box>
+  ))
+}
+
+function FitchRuleGroup({ group }) {
+  const [expanded, setExpanded] = useState(true)
+
+  if (!group.title) {
+    return <FitchRuleEntries group={group} />
+  }
+
+  return (
+    <Box sx={{ '&:not(:last-child)': { mb: 1 } }}>
+      <Box
+        component="button"
+        type="button"
+        aria-expanded={expanded}
+        onClick={() => setExpanded((current) => !current)}
+        sx={{
+          width: '100%',
+          border: 0,
+          borderRadius: 1,
+          bgcolor: (t) => alpha(t.palette.primary.main, 0.06),
+          color: 'primary.main',
+          py: 1,
+          px: 1,
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'space-between',
+          gap: 1,
+          textAlign: 'left',
+          cursor: 'pointer',
+          '&:hover': { bgcolor: (t) => alpha(t.palette.primary.main, 0.1) },
+        }}
+      >
+        <Typography component="span" sx={{ fontWeight: 700, fontSize: '0.95rem' }}>
+          {group.title}
+        </Typography>
+        {expanded ? <ExpandLessIcon fontSize="small" /> : <ExpandMoreIcon fontSize="small" />}
+      </Box>
+      {expanded && <FitchRuleEntries group={group} />}
+    </Box>
+  )
+}
+
+function FitchRuleGroups({ groups }) {
+  return groups.map((group) => (
+    <FitchRuleGroup key={group.title || `rules-${group.start}`} group={group} />
+  ))
+}
+
 export default function RulesReference({ logicSystem }) {
   const { isRulesReferenceOpen } = useLayoutState()
   const dispatch = useLayoutDispatch()
@@ -128,44 +243,18 @@ export default function RulesReference({ logicSystem }) {
         </Box>
       </RulesCard>
       
-      <RulesCard title="Rules of Inference" defaultExpanded={false}>
+      <RulesCard title={isFitch ? 'Natural Deduction Rules for TFL' : 'Rules of Inference'} defaultExpanded={false}>
         {isFitch ? (
           <>
-            <Typography variant="subtitle2" sx={{ fontWeight: 700, mb: 0.5, color: 'primary.main', fontSize: '0.95rem' }}>
-              Basic TFL Rules
-            </Typography>
-            <Box component="div" sx={{ mb: 1.5, fontSize: '0.85rem' }}>
-              <div><strong>R:</strong> A / A</div>
-              <div><strong>∧I:</strong> A, B / A ∧ B</div>
-              <div><strong>∧E:</strong> A ∧ B / A</div>
-              <div style={{ paddingLeft: '28px' }}>A ∧ B / B</div>
-              <div><strong>→I:</strong> subproof A ⟹ B / A → B</div>
-              <div><strong>→E:</strong> A → B, A / B</div>
-              <div><strong>↔I:</strong> subproof A ⟹ B, subproof B ⟹ A / A ↔ B</div>
-              <div><strong>↔E:</strong> A ↔ B, A / B</div>
-              <div style={{ paddingLeft: '28px' }}>A ↔ B, B / A</div>
-              <div><strong>∨I:</strong> A / A ∨ B</div>
-              <div style={{ paddingLeft: '28px' }}>A / B ∨ A</div>
-              <div><strong>∨E:</strong> A ∨ B, subproof A ⟹ C, subproof B ⟹ C / C</div>
-              <div><strong>¬I:</strong> subproof A ⟹ ⊥ / ¬A</div>
-              <div><strong>¬E:</strong> A, ¬A / ⊥</div>
-              <div><strong>IP:</strong> subproof ¬A ⟹ ⊥ / A</div>
-              <div><strong>X:</strong> ⊥ / A</div>
+            <Box sx={{ mb: 2, p: 1, borderRadius: 1, bgcolor: (t) => alpha(t.palette.primary.main, 0.06) }}>
+              <Typography component="div" sx={{ mb: 0.75, fontSize: '0.85rem', fontWeight: 700 }}>Definitions</Typography>
+              {FITCH_DEFINITIONS.map((definition) => (
+                <Typography key={definition.text} component="p" sx={{ m: 0, '&:not(:last-child)': { mb: 1 }, fontSize: '0.8rem', color: 'text.primary' }}>
+                  <EmphasizedText text={definition.text} bold={definition.bold} />
+                </Typography>
+              ))}
             </Box>
-            <Typography variant="subtitle2" sx={{ fontWeight: 700, mb: 0.5, color: 'primary.main', fontSize: '0.95rem' }}>
-              Additional TFL Rules
-            </Typography>
-            <Box component="div" sx={{ fontSize: '0.85rem' }}>
-              <div><strong>DS:</strong> A ∨ B, ¬A / B</div>
-              <div style={{ paddingLeft: '28px' }}>A ∨ B, ¬B / A</div>
-              <div><strong>MT:</strong> A → B, ¬B / ¬A</div>
-              <div><strong>DNE:</strong> ¬¬A / A</div>
-              <div><strong>LEM:</strong> subproof A ⟹ C, subproof ¬A ⟹ C / C</div>
-              <div><strong>DeM:</strong> ¬(A ∧ B) / ¬A ∨ ¬B</div>
-              <div style={{ paddingLeft: '28px' }}>¬A ∨ ¬B / ¬(A ∧ B)</div>
-              <div style={{ paddingLeft: '28px' }}>¬(A ∨ B) / ¬A ∧ ¬B</div>
-              <div style={{ paddingLeft: '28px' }}>¬A ∧ ¬B / ¬(A ∨ B)</div>
-            </Box>
+            <FitchRuleGroups groups={FITCH_TFL_RULE_GROUPS} />
           </>
         ) : (
           <>
@@ -217,37 +306,14 @@ export default function RulesReference({ logicSystem }) {
         )}
       </RulesCard>
       
-      <RulesCard title="Predicate Logic Rules" defaultExpanded={false}>
-        <Typography variant="subtitle2" sx={{ fontWeight: 700, mb: 0.5, color: 'primary.main', fontSize: '0.95rem' }}>
-          Predicate Logic Rules
-        </Typography>
+      <RulesCard title={isFitch ? 'Natural Deduction Rules for FOL' : 'Predicate Logic Rules'} defaultExpanded={false}>
+        {!isFitch && (
+          <Typography variant="subtitle2" sx={{ fontWeight: 700, mb: 0.5, color: 'primary.main', fontSize: '0.95rem' }}>
+            Predicate Logic Rules
+          </Typography>
+        )}
         {isFitch ? (
-          <>
-            <Box component="div" sx={{ mb: 1.5, fontSize: '0.85rem' }}>
-              <div><strong>∀E:</strong> ∀xFx / Fa</div>
-              <div><strong>∃I:</strong> Fa / ∃xFx</div>
-              <div><strong>∀I:</strong> Fa / ∀xFx, when a does not occur in any undischarged assumption</div>
-              <div><strong>∃E:</strong> ∃xFx plus subproof Fa ⟹ B / B</div>
-              <div style={{ paddingLeft: '28px' }}>a must not occur in any undischarged assumption, the existential premise, or the conclusion</div>
-            </Box>
-            <Typography variant="subtitle2" sx={{ fontWeight: 700, mb: 0.5, color: 'primary.main', fontSize: '0.95rem' }}>
-              Conversion of Quantifiers
-            </Typography>
-            <Box component="div" sx={{ mb: 1.5, fontSize: '0.85rem' }}>
-              <div><strong>CQ:</strong> ∀x¬Fx / ¬∃xFx</div>
-              <div><strong>CQ:</strong> ¬∃xFx / ∀x¬Fx</div>
-              <div><strong>CQ:</strong> ∃x¬Fx / ¬∀xFx</div>
-              <div><strong>CQ:</strong> ¬∀xFx / ∃x¬Fx</div>
-            </Box>
-            <Typography variant="subtitle2" sx={{ fontWeight: 700, mb: 0.5, color: 'primary.main', fontSize: '0.95rem' }}>
-              Identity Rules
-            </Typography>
-            <Box component="div" sx={{ mb: 1.5, fontSize: '0.85rem' }}>
-              <div><strong>=I:</strong> a = a</div>
-              <div><strong>=E:</strong> a = b, Fa / Fb</div>
-              <div style={{ paddingLeft: '28px' }}>replace one or more occurrences in either direction</div>
-            </Box>
-          </>
+          <FitchRuleGroups groups={FITCH_FOL_RULE_GROUPS} />
         ) : (
           <>
             <Box component="div" sx={{ mb: 1.5, fontSize: '0.85rem' }}>
@@ -269,25 +335,16 @@ export default function RulesReference({ logicSystem }) {
         )}
       </RulesCard>
 
-      <RulesCard title="Conditional & Indirect Proofs" defaultExpanded={false}>
-        <Box component="div" sx={{ fontSize: '0.85rem' }}>
-          {isFitch ? (
-            <>
-              <div><strong>AS:</strong> starts a subproof assumption</div>
-              <div><strong>→I:</strong> discharge a subproof from A to B</div>
-              <div><strong>¬I:</strong> discharge a subproof from A to ⊥</div>
-              <div><strong>IP:</strong> discharge a subproof from ¬A to ⊥</div>
-            </>
-          ) : (
-            <>
-              <div><strong>ACP:</strong> Assumption for Conditional Proof</div>
-              <div><strong>CP:</strong> To prove p ⊃ q, assume p (ACP) in an indented subderivation, derive q, then discharge with CP citing the subderivation range</div>
-              <div><strong>AIP:</strong> Assumption for Indirect Proof</div>
-              <div><strong>IP:</strong> To prove ~p, assume p (AIP) in an indented subderivation, derive a contradiction (q • ~q), then discharge with IP citing the subderivation range</div>
-            </>
-          )}
-        </Box>
-      </RulesCard>
+      {!isFitch && (
+        <RulesCard title="Conditional & Indirect Proofs" defaultExpanded={false}>
+          <Box component="div" sx={{ fontSize: '0.85rem' }}>
+            <div><strong>ACP:</strong> Assumption for Conditional Proof</div>
+            <div><strong>CP:</strong> To prove p ⊃ q, assume p (ACP) in an indented subderivation, derive q, then discharge with CP citing the subderivation range</div>
+            <div><strong>AIP:</strong> Assumption for Indirect Proof</div>
+            <div><strong>IP:</strong> To prove ~p, assume p (AIP) in an indented subderivation, derive a contradiction (q • ~q), then discharge with IP citing the subderivation range</div>
+          </Box>
+        </RulesCard>
+      )}
     </Box>
   )
   
@@ -309,8 +366,8 @@ export default function RulesReference({ logicSystem }) {
     return (
       <Box
         sx={{
-          width: isRulesReferenceOpen ? 'clamp(280px, 24vw, 360px)' : 0,
-          maxWidth: isRulesReferenceOpen ? 'min(360px, 32vw)' : 0,
+          width: isRulesReferenceOpen ? 'clamp(380px, 32vw, 520px)' : 0,
+          maxWidth: isRulesReferenceOpen ? 'min(520px, 40vw)' : 0,
           minWidth: 0,
           flexShrink: 0,
           overflow: 'hidden',
@@ -348,8 +405,8 @@ export default function RulesReference({ logicSystem }) {
       sx={{
         display: 'block',
         '& .MuiDrawer-paper': {
-          width: { xs: '85%', sm: '400px' },
-          maxWidth: '400px',
+          width: { xs: '92%', sm: '480px' },
+          maxWidth: 'min(480px, 92vw)',
         },
       }}
     >

--- a/src/components/ui/logicpenguin/LogicSymbol.jsx
+++ b/src/components/ui/logicpenguin/LogicSymbol.jsx
@@ -8,6 +8,8 @@ const SYMBOL_SPEECH = {
   '≡': 'triple bar',
   '∀': 'universal quantifier',
   '∃': 'existential quantifier',
+  '⊥': 'contradiction',
+  '✖': 'contradiction',
 }
 
 const EXPR_SPEECH = {
@@ -27,6 +29,7 @@ const PUNCT_SPEECH = {
   '{': 'left brace',
   '}': 'right brace',
   '/': 'slash',
+  '_': 'subscript',
 }
 
 const getSymbolSpeech = (symbol) => {

--- a/src/components/ui/logicpenguin/SymbolButtonRow.jsx
+++ b/src/components/ui/logicpenguin/SymbolButtonRow.jsx
@@ -70,8 +70,9 @@ export default function SymbolButtonRow({
     return syntax?.mkquantifier?.('x', sym) ?? `${sym}x`
   }
 
-  const resolveLabel = (op, quantifier = false, insert = null, pair = null, backspace = false) => {
+  const resolveLabel = ({ op, quantifier = false, insert = null, pair = null, backspace = false, label }) => {
     if (backspace) return '←'
+    if (label) return label
     if (insert) return insert
     if (pair) {
       const open = pair[0]
@@ -193,10 +194,10 @@ export default function SymbolButtonRow({
         useFlexGap
         sx={centerButtons ? { justifyContent: 'center' } : undefined}
       >
-        {visibleButtons.map(({ op, quantifier, insert, pair, backspace }) => {
-          const visualSymbol = resolveLabel(op, quantifier, insert, pair, backspace)
+        {visibleButtons.map(({ op, quantifier, insert, pair, backspace, label }) => {
+          const visualSymbol = resolveLabel({ op, quantifier, insert, pair, backspace, label })
           const a11yLabel = backspace ? 'Backspace' : getInsertSymbolLabel({
-            insert: pair ? null : visualSymbol,
+            insert: pair ? null : insert || visualSymbol,
             pair,
           })
           return (

--- a/src/lib/fitchRuleExamples.js
+++ b/src/lib/fitchRuleExamples.js
@@ -6,6 +6,8 @@ const C = String.raw`\mathscr{C}`
 const table = (rows) => tex`\begin{array}{r|l@{\qquad}l}${rows}\end{array}`
 const subproof = (rows) => tex`\begin{array}{r|l@{\qquad}l}${rows}\end{array}`
 const justified = (formula, justification) => tex`${formula}&${justification}`
+const assumptionFormula = (formula) => tex`\hspace{-0.5em}\underline{\hspace{0.5em}${formula}}`
+const assumption = (formula) => justified(assumptionFormula(formula), tex`\mathrm{AS}`)
 const stack = (...examples) => tex`\begin{gathered}${examples.join(String.raw`\\[1.1em]`)}\end{gathered}`
 
 
@@ -15,9 +17,9 @@ export const FITCH_RULE_EXAMPLES = {
     table(tex`m&${A}\land${B}\\&${justified(A, tex`\land E\ m`)}`),
     table(tex`m&${A}\land${B}\\&${justified(B, tex`\land E\ m`)}`),
   )],
-  '→I': [table(tex`&${subproof(tex`m&${justified(A, tex`\mathrm{AS}`)}\\n&${B}`)}\\&${justified(tex`${A}\to${B}`, tex`\to I\ m\text{-}n`)}`)],
+  '→I': [table(tex`&${subproof(tex`m&${assumption(A)}\\n&${B}`)}\\&${justified(tex`${A}\to${B}`, tex`\to I\ m\text{-}n`)}`)],
   '→E': [table(tex`m&${A}\to${B}\\n&${A}\\&${justified(B, tex`\to E\ m,n`)}`)],
-  '↔I': [table(tex`&${subproof(tex`i&${justified(A, tex`\mathrm{AS}`)}\\j&${B}`)}\\&${subproof(tex`k&${justified(B, tex`\mathrm{AS}`)}\\l&${A}`)}\\&${justified(tex`${A}\leftrightarrow${B}`, tex`\leftrightarrow I\ i\text{-}j,k\text{-}l`)}`)],
+  '↔I': [table(tex`&${subproof(tex`i&${assumption(A)}\\j&${B}`)}\\&${subproof(tex`k&${assumption(B)}\\l&${A}`)}\\&${justified(tex`${A}\leftrightarrow${B}`, tex`\leftrightarrow I\ i\text{-}j,k\text{-}l`)}`)],
   '↔E': [
     table(tex`m&${A}\leftrightarrow${B}\\n&${A}\\&${justified(B, tex`\leftrightarrow E\ m,n`)}`),
     table(tex`m&${A}\leftrightarrow${B}\\n&${B}\\&${justified(A, tex`\leftrightarrow E\ m,n`)}`),
@@ -26,10 +28,10 @@ export const FITCH_RULE_EXAMPLES = {
     table(tex`m&${A}\\&${justified(tex`${A}\lor${B}`, tex`\lor I\ m`)}`),
     table(tex`m&${A}\\&${justified(tex`${B}\lor${A}`, tex`\lor I\ m`)}`),
   ],
-  '∨E': [table(tex`m&${A}\lor${B}\\&${subproof(tex`i&${justified(A, tex`\mathrm{AS}`)}\\j&${C}`)}\\&${subproof(tex`k&${justified(B, tex`\mathrm{AS}`)}\\l&${C}`)}\\&${justified(C, tex`\lor E\ m,i\text{-}j,k\text{-}l`)}`)],
-  '¬I': [table(tex`&${subproof(tex`i&${justified(A, tex`\mathrm{AS}`)}\\j&\bot`)}\\&${justified(tex`\neg${A}`, tex`\neg I\ i\text{-}j`)}`)],
+  '∨E': [table(tex`m&${A}\lor${B}\\&${subproof(tex`i&${assumption(A)}\\j&${C}`)}\\&${subproof(tex`k&${assumption(B)}\\l&${C}`)}\\&${justified(C, tex`\lor E\ m,i\text{-}j,k\text{-}l`)}`)],
+  '¬I': [table(tex`&${subproof(tex`i&${assumption(A)}\\j&\bot`)}\\&${justified(tex`\neg${A}`, tex`\neg I\ i\text{-}j`)}`)],
   '¬E': [table(tex`m&\neg${A}\\n&${A}\\&${justified(tex`\bot`, tex`\neg E\ m,n`)}`)],
-  IP: [table(tex`&${subproof(tex`i&${justified(tex`\neg${A}`, tex`\mathrm{AS}`)}\\j&\bot`)}\\&${justified(A, tex`\mathrm{IP}\ i\text{-}j`)}`)],
+  IP: [table(tex`&${subproof(tex`i&${assumption(tex`\neg${A}`)}\\j&\bot`)}\\&${justified(A, tex`\mathrm{IP}\ i\text{-}j`)}`)],
   X: [table(tex`m&\bot\\&${justified(A, tex`\mathrm X\ m`)}`)],
   R: [table(tex`m&${A}\\&${justified(A, tex`\mathrm R\ m`)}`)],
   DS: [
@@ -38,7 +40,7 @@ export const FITCH_RULE_EXAMPLES = {
   ],
   MT: [table(tex`m&${A}\to${B}\\n&\neg${B}\\&${justified(tex`\neg${A}`, tex`\mathrm{MT}\ m,n`)}`)],
   DNE: [table(tex`m&\neg\neg${A}\\&${justified(A, tex`\mathrm{DNE}\ m`)}`)],
-  LEM: [table(tex`&${subproof(tex`i&${justified(A, tex`\mathrm{AS}`)}\\j&${B}`)}\\&${subproof(tex`k&${justified(tex`\neg${A}`, tex`\mathrm{AS}`)}\\l&${B}`)}\\&${justified(B, tex`\mathrm{LEM}\ i\text{-}j,k\text{-}l`)}`)],
+  LEM: [table(tex`&${subproof(tex`i&${assumption(A)}\\j&${B}`)}\\&${subproof(tex`k&${assumption(tex`\neg${A}`)}\\l&${B}`)}\\&${justified(B, tex`\mathrm{LEM}\ i\text{-}j,k\text{-}l`)}`)],
   DeM: [stack(
     table(tex`m&\neg(${A}\land${B})\\&${justified(tex`\neg${A}\lor\neg${B}`, tex`\mathrm{DeM}\ m`)}`),
     table(tex`m&\neg${A}\lor\neg${B}\\&${justified(tex`\neg(${A}\land${B})`, tex`\mathrm{DeM}\ m`)}`),
@@ -48,7 +50,7 @@ export const FITCH_RULE_EXAMPLES = {
   '∀E': [table(tex`m&\forall x\,${A}(\ldots x\ldots)\\&${justified(tex`${A}(\ldots c\ldots)`, tex`\forall E\ m`)}`)],
   '∀I': [table(tex`m&${A}(\ldots c\ldots)\\&${justified(tex`\forall x\,${A}(\ldots x\ldots)`, tex`\forall I\ m`)}`)],
   '∃I': [table(tex`m&${A}(\ldots c\ldots)\\&${justified(tex`\exists x\,${A}(\ldots x\ldots)`, tex`\exists I\ m`)}`)],
-  '∃E': [table(tex`m&\exists x\,${A}(\ldots x\ldots)\\&${subproof(tex`i&${justified(tex`${A}(\ldots c\ldots)`, tex`\mathrm{AS}`)}\\j&${B}`)}\\&${justified(B, tex`\exists E\ m,i\text{-}j`)}`)],
+  '∃E': [table(tex`m&\exists x\,${A}(\ldots x\ldots)\\&${subproof(tex`i&${assumption(tex`${A}(\ldots c\ldots)`)}\\j&${B}`)}\\&${justified(B, tex`\exists E\ m,i\text{-}j`)}`)],
   CQ: [stack(
     table(tex`m&\forall x\,\neg${A}\\&${justified(tex`\neg\exists x\,${A}`, tex`\mathrm{CQ}\ m`)}`),
     table(tex`m&\neg\exists x\,${A}\\&${justified(tex`\forall x\,\neg${A}`, tex`\mathrm{CQ}\ m`)}`),

--- a/src/lib/fitchRuleExamples.js
+++ b/src/lib/fitchRuleExamples.js
@@ -1,0 +1,63 @@
+const tex = String.raw
+const A = String.raw`\mathscr{A}`
+const B = String.raw`\mathscr{B}`
+const C = String.raw`\mathscr{C}`
+
+const table = (rows) => tex`\begin{array}{r|l@{\qquad}l}${rows}\end{array}`
+const subproof = (rows) => tex`\begin{array}{r|l@{\qquad}l}${rows}\end{array}`
+const justified = (formula, justification) => tex`${formula}&${justification}`
+const stack = (...examples) => tex`\begin{gathered}${examples.join(String.raw`\\[1.1em]`)}\end{gathered}`
+
+
+export const FITCH_RULE_EXAMPLES = {
+  '∧I': [table(tex`m&${A}\\n&${B}\\&${justified(tex`${A}\land${B}`, tex`\land I\ m,n`)}`)],
+  '∧E': [stack(
+    table(tex`m&${A}\land${B}\\&${justified(A, tex`\land E\ m`)}`),
+    table(tex`m&${A}\land${B}\\&${justified(B, tex`\land E\ m`)}`),
+  )],
+  '→I': [table(tex`&${subproof(tex`m&${justified(A, tex`\mathrm{AS}`)}\\n&${B}`)}\\&${justified(tex`${A}\to${B}`, tex`\to I\ m\text{-}n`)}`)],
+  '→E': [table(tex`m&${A}\to${B}\\n&${A}\\&${justified(B, tex`\to E\ m,n`)}`)],
+  '↔I': [table(tex`&${subproof(tex`i&${justified(A, tex`\mathrm{AS}`)}\\j&${B}`)}\\&${subproof(tex`k&${justified(B, tex`\mathrm{AS}`)}\\l&${A}`)}\\&${justified(tex`${A}\leftrightarrow${B}`, tex`\leftrightarrow I\ i\text{-}j,k\text{-}l`)}`)],
+  '↔E': [
+    table(tex`m&${A}\leftrightarrow${B}\\n&${A}\\&${justified(B, tex`\leftrightarrow E\ m,n`)}`),
+    table(tex`m&${A}\leftrightarrow${B}\\n&${B}\\&${justified(A, tex`\leftrightarrow E\ m,n`)}`),
+  ],
+  '∨I': [
+    table(tex`m&${A}\\&${justified(tex`${A}\lor${B}`, tex`\lor I\ m`)}`),
+    table(tex`m&${A}\\&${justified(tex`${B}\lor${A}`, tex`\lor I\ m`)}`),
+  ],
+  '∨E': [table(tex`m&${A}\lor${B}\\&${subproof(tex`i&${justified(A, tex`\mathrm{AS}`)}\\j&${C}`)}\\&${subproof(tex`k&${justified(B, tex`\mathrm{AS}`)}\\l&${C}`)}\\&${justified(C, tex`\lor E\ m,i\text{-}j,k\text{-}l`)}`)],
+  '¬I': [table(tex`&${subproof(tex`i&${justified(A, tex`\mathrm{AS}`)}\\j&\bot`)}\\&${justified(tex`\neg${A}`, tex`\neg I\ i\text{-}j`)}`)],
+  '¬E': [table(tex`m&\neg${A}\\n&${A}\\&${justified(tex`\bot`, tex`\neg E\ m,n`)}`)],
+  IP: [table(tex`&${subproof(tex`i&${justified(tex`\neg${A}`, tex`\mathrm{AS}`)}\\j&\bot`)}\\&${justified(A, tex`\mathrm{IP}\ i\text{-}j`)}`)],
+  X: [table(tex`m&\bot\\&${justified(A, tex`\mathrm X\ m`)}`)],
+  R: [table(tex`m&${A}\\&${justified(A, tex`\mathrm R\ m`)}`)],
+  DS: [
+    table(tex`m&${A}\lor${B}\\n&\neg${A}\\&${justified(B, tex`\mathrm{DS}\ m,n`)}`),
+    table(tex`m&${A}\lor${B}\\n&\neg${B}\\&${justified(A, tex`\mathrm{DS}\ m,n`)}`),
+  ],
+  MT: [table(tex`m&${A}\to${B}\\n&\neg${B}\\&${justified(tex`\neg${A}`, tex`\mathrm{MT}\ m,n`)}`)],
+  DNE: [table(tex`m&\neg\neg${A}\\&${justified(A, tex`\mathrm{DNE}\ m`)}`)],
+  LEM: [table(tex`&${subproof(tex`i&${justified(A, tex`\mathrm{AS}`)}\\j&${B}`)}\\&${subproof(tex`k&${justified(tex`\neg${A}`, tex`\mathrm{AS}`)}\\l&${B}`)}\\&${justified(B, tex`\mathrm{LEM}\ i\text{-}j,k\text{-}l`)}`)],
+  DeM: [stack(
+    table(tex`m&\neg(${A}\land${B})\\&${justified(tex`\neg${A}\lor\neg${B}`, tex`\mathrm{DeM}\ m`)}`),
+    table(tex`m&\neg${A}\lor\neg${B}\\&${justified(tex`\neg(${A}\land${B})`, tex`\mathrm{DeM}\ m`)}`),
+    table(tex`m&\neg(${A}\lor${B})\\&${justified(tex`\neg${A}\land\neg${B}`, tex`\mathrm{DeM}\ m`)}`),
+    table(tex`m&\neg${A}\land\neg${B}\\&${justified(tex`\neg(${A}\lor${B})`, tex`\mathrm{DeM}\ m`)}`),
+  )],
+  '∀E': [table(tex`m&\forall x\,${A}(\ldots x\ldots)\\&${justified(tex`${A}(\ldots c\ldots)`, tex`\forall E\ m`)}`)],
+  '∀I': [table(tex`m&${A}(\ldots c\ldots)\\&${justified(tex`\forall x\,${A}(\ldots x\ldots)`, tex`\forall I\ m`)}`)],
+  '∃I': [table(tex`m&${A}(\ldots c\ldots)\\&${justified(tex`\exists x\,${A}(\ldots x\ldots)`, tex`\exists I\ m`)}`)],
+  '∃E': [table(tex`m&\exists x\,${A}(\ldots x\ldots)\\&${subproof(tex`i&${justified(tex`${A}(\ldots c\ldots)`, tex`\mathrm{AS}`)}\\j&${B}`)}\\&${justified(B, tex`\exists E\ m,i\text{-}j`)}`)],
+  CQ: [stack(
+    table(tex`m&\forall x\,\neg${A}\\&${justified(tex`\neg\exists x\,${A}`, tex`\mathrm{CQ}\ m`)}`),
+    table(tex`m&\neg\exists x\,${A}\\&${justified(tex`\forall x\,\neg${A}`, tex`\mathrm{CQ}\ m`)}`),
+    table(tex`m&\exists x\,\neg${A}\\&${justified(tex`\neg\forall x\,${A}`, tex`\mathrm{CQ}\ m`)}`),
+    table(tex`m&\neg\forall x\,${A}\\&${justified(tex`\exists x\,\neg${A}`, tex`\mathrm{CQ}\ m`)}`),
+  )],
+  '=I': [table(tex`&${justified(tex`c=c`, tex`{=}I`)}`)],
+  '=E': [
+    table(tex`m&a=b\\n&${A}(\ldots a\ldots)\\&${justified(tex`${A}(\ldots b\ldots)`, tex`{=}E\ m,n`)}`),
+    table(tex`m&a=b\\n&${A}(\ldots b\ldots)\\&${justified(tex`${A}(\ldots a\ldots)`, tex`{=}E\ m,n`)}`),
+  ],
+}

--- a/src/lib/fitchRulebook.js
+++ b/src/lib/fitchRulebook.js
@@ -1,0 +1,58 @@
+// Dr. Yuna Won's Fitch Natural Deduction Rulebook 
+
+export const FITCH_DEFINITIONS = [
+  {
+    text: 'A sentence is available at a given point in a natural deduction proof if it occurs on an earlier line and is not contained in a discharged (closed) subproof. In other words, it must appear either in the current subproof or in an outer subproof that contains the current one.',
+    bold: ['available'],
+  },
+  {
+    text: 'A subproof is discharged when you finish using the assumption that opened the subproof and apply a rule that allows you to close it. Once discharged, the assumption is no longer available outside that subproof.',
+    bold: ['subproof', 'discharged'],
+  },
+]
+
+export const FITCH_TFL_RULE_GROUPS = [
+  {
+    title: '12 Basic Rules',
+    start: 1,
+    rules: [
+      { name: '∧I', title: 'Conjunction Introduction', forms: ['A, B / A ∧ B'], description: 'The Conjunction Introduction rule (∧I) allows us to combine sentences on two different lines into a conjunction, provided that both lines are available.', bold: ['Conjunction Introduction'] },
+      { name: '∧E', title: 'Conjunction Elimination', forms: ['A ∧ B / A', 'A ∧ B / B'], description: 'The Conjunction Elimination rule (∧E) allows us to derive either conjunct of a conjunction on a line by itself.', bold: ['Conjunction Elimination'] },
+      { name: '→I', title: 'Conditional Introduction', forms: ['subproof A ⟹ B / A → B'], description: 'The Conditional Introduction rule (→I) allows us to derive a conditional by opening a subproof with its antecedent as an assumption and deriving its consequent within that subproof.', bold: ['Conditional Introduction'], note: 'This rule involves a subproof starting with an additional assumption (AS). You discharge the subproof by writing a new conditional sentence outside of the subproof.' },
+      { name: '→E', title: 'Conditional Elimination', forms: ['A → B, A / B'], description: 'The conditional elimination rule (→E) allows us to derive the consequent of a conditional if the conditional and its antecedent are available sentences.' },
+      { name: '↔I', title: 'Biconditional Introduction', forms: ['subproof A ⟹ B, subproof B ⟹ A / A ↔ B'], description: 'The Biconditional Introduction rule (↔I) allows us to derive a biconditional by performing two subproofs: one from left to right and the other from right to left.', bold: ['Biconditional Introduction'] },
+      { name: '↔E', title: 'Biconditional Elimination', forms: ['A ↔ B, A / B', 'A ↔ B, B / A'], description: 'The Biconditional Elimination rule (↔E) allows us to use a biconditional in either direction when we have either its left-hand or right-hand subsentence in the proof.', bold: ['Biconditional Elimination'] },
+      { name: '∨I', title: 'Disjunction Introduction', forms: ['A / A ∨ B', 'A / B ∨ A'], description: 'The Disjunction Introduction rule (∨I) allows us to derive a disjunction from an available sentence by connecting it with any sentence using ∨, either on the left or on the right.', bold: ['Disjunction Introduction'] },
+      { name: '∨E', title: 'Disjunction Elimination', forms: ['A ∨ B, subproof A ⟹ C, subproof B ⟹ C / C'], description: 'The Disjunction Elimination (∨E) rule allows us to derive a sentence from a disjunction when we can derive that same sentence from each of its disjuncts in separate subproofs.', bold: ['Disjunction Elimination'], note: 'Both subproofs for ∨E must end with the same conclusion, with each subproof beginning with one of the disjuncts as an assumption. The justification must include the rule name (∨E) and the line numbers of the disjunction and both subproofs.', noteLabelBold: true },
+      { name: '¬I', title: 'Negation Introduction', forms: ['subproof A ⟹ ⊥ / ¬A'], description: 'The Negation Introduction rule (¬I) allows us to derive a negated sentence by showing that assuming the unnegated sentence for a subproof leads to a contradiction (⊥).', bold: ['Negation Introduction'] },
+      { name: '¬E', title: 'Negation Elimination', forms: ['A, ¬A / ⊥'], description: 'The Negation Elimination rule (¬E) allows us to derive a contradiction (⊥) by having both a sentence and its negation available in the proof.', bold: ['Negation Elimination'] },
+      { name: 'IP', title: 'Indirect Proof', forms: ['subproof ¬A ⟹ ⊥ / A'], description: 'The Indirect Proof rule (IP) allows us to derive a sentence by showing that assuming its negation leads to a contradiction.', bold: ['Indirect Proof'], note: '¬I and IP are different rules. ¬I is used to derive a negated sentence, while IP is used to derive an unnegated sentence by showing that assuming its negation leads to a contradiction.', noteBold: ['¬I', 'IP'], noteLabelBold: true },
+      { name: 'X', title: 'Explosion', forms: ['⊥ / A'], description: 'The Explosion rule (X) allows us to derive any sentence from a contradiction (⊥).', bold: ['Explosion'] },
+    ],
+  },
+  {
+    title: 'Derived Rules',
+    start: 13,
+    rules: [
+      { name: 'R', title: 'Reiteration', forms: ['A / A'], description: 'The Reiteration rule (R) allows us to repeat any available sentence on a new line. A sentence is available if it does not occur within a discharged subproof.', bold: ['Reiteration'] },
+      { name: 'DS', title: 'Disjunctive Syllogism', forms: ['A ∨ B, ¬A / B', 'A ∨ B, ¬B / A'], description: 'The Disjunctive Syllogism rule (DS) allows us to derive one disjunct from a disjunction when we have the negation of the other disjunct.', bold: ['Disjunctive Syllogism'] },
+      { name: 'MT', title: 'Modus Tollens', forms: ['A → B, ¬B / ¬A'], description: 'The Modus Tollens rule (MT) allows us to derive the negation of the antecedent of a conditional when we have the negation of its consequent.', bold: ['Modus Tollens'] },
+      { name: 'DNE', title: 'Double Negation Elimination', forms: ['¬¬A / A'], description: 'The Double Negation Elimination rule (DNE) allows us to derive an unnegated sentence from its double negation.', bold: ['Double Negation Elimination'] },
+      { name: 'LEM', title: 'The Law of Excluded Middle', forms: ['subproof A ⟹ C, subproof ¬A ⟹ C / C'], description: 'The Law of Excluded Middle rule (LEM) allows us to derive a sentence by showing, in two separate subproofs, that the same sentence follows from both a sentence and its negation.', bold: ['Law of Excluded Middle'], note: 'You can think of it as ∨E applied to A ∨ ¬A, and A can be any sentence.' },
+      { name: 'DeM', title: 'De Morgan’s Rule', forms: ['¬(A ∧ B) / ¬A ∨ ¬B', '¬A ∨ ¬B / ¬(A ∧ B)', '¬(A ∨ B) / ¬A ∧ ¬B', '¬A ∧ ¬B / ¬(A ∨ B)'], description: 'De Morgan’s rule (DeM) allows us to replace a negated conjunction with a disjunction of the negated conjuncts, or a negated disjunction with a conjunction of the negated disjuncts, and vice versa. So there are four versions of the rule.', bold: ['De Morgan’s'] },
+    ],
+  },
+]
+
+export const FITCH_FOL_RULE_GROUPS = [{
+  start: 1,
+  rules: [
+    { name: '∀E', title: 'Universal Elimination', forms: ['∀xFx / Fa'], description: 'The Universal Elimination rule (∀E) allows us to derive a sentence about a particular individual from a universally quantified sentence.', bold: ['Universal Elimination'], notes: [{ text: 'When using the ∀E rule, replace every occurrence of the variable governed by the universal quantifier with the same name. The name may be one that has already appeared in the proof or a new name.' }, { text: 'The sentence resulting from an application of the ∀E rule is called a substitution instance.', bold: ['substitution instance'] }] },
+    { name: '∀I', title: 'Universal Introduction', forms: ['Fa / ∀xFx'], description: 'The Universal Introduction rule (∀I) allows us to derive a universally quantified sentence from a substitution instance containing an arbitrary name that does not appear in any premises or undischarged assumptions.', bold: ['Universal Introduction'] },
+    { name: '∃I', title: 'Existential Introduction', forms: ['Fa / ∃xFx'], description: 'The Existential Introduction rule (∃I) allows us to derive an existentially quantified sentence from one of its substitution instances.', bold: ['Existential Introduction'] },
+    { name: '∃E', title: 'Existential Elimination', forms: ['∃xFx, subproof Fa ⟹ B / B'], description: 'The Existential Elimination rule (∃E) allows us to derive a sentence from an existentially quantified sentence by opening a subproof with a substitution instance containing a new arbitrary name and deriving the desired conclusion within that subproof.', bold: ['Existential Elimination'], notes: [{ text: 'The arbitrary name must not occur in any assumption undischarged before the existential premise.' }, { text: 'The arbitrary name must not occur in the existential premise.' }, { text: 'The arbitrary name must not occur in the conclusion.' }] },
+    { name: 'CQ', title: 'Conversion of Quantifiers', forms: ['∀xAx :: ¬∃x¬Ax', '∃xAx :: ¬∀x¬Ax'], description: 'The Conversion of Quantifiers rule (CQ) allows us to convert between universal and existential quantifiers by changing the quantifier and appropriately moving the negation. This rule holds because the following two pairs of formulas are logically equivalent.', bold: ['Conversion of Quantifiers'] },
+    { name: '=I', title: 'Identity Introduction', forms: ['a = a'], description: 'The Identity Introduction rule (=I) allows us to derive a statement that any name is identical to itself.', bold: ['Identity Introduction'] },
+    { name: '=E', title: 'Identity Elimination', forms: ['a = b, Fa / Fb', 'a = b, Fb / Fa'], description: 'The Identity Elimination rule (=E) allows us to substitute one name for another when we know that the two names refer to the same object.', bold: ['Identity Elimination'] },
+  ],
+}]


### PR DESCRIPTION
## 📝 Description

This creates a new Fitch natural deduction rulebook with examples from *forall x*, using Dr. Yuna Won’s notes.

The rulebook contains:

- 12 basic TFL rules, 6 derived TFL rules, 7 FOL rules in grouped collapsible sections
- explanations, restrictions, and notes for each rule
- MathJax rendering proof examples of every rule
- a symbol shortcut table covering connectives, quantifiers, contradiction, and numeric subscripts

Closing the rulebook now restores focus to its trigger. This also adds contradiction and subscript buttons to the derivation keyboard and connects assumption underlines to their vertical subproof lines.

## 🚀 Type of Change

- [ ] 🐛 Bug fix
- [x] ✨ New feature
- [ ] 🛠️ Refactor / Chore (Code cleanup, dependency update, etc.)

## 🧪 How to Test

1. Pull down this branch and run `npm run dev`
2. Open the rulebook from a Fitch course
3. Expand the TFL, FOL, and shortcut sections
4. Verify all rule descriptions and MathJax proof examples render
5. Verify the examples show assumptions, subproofs, and citations correctly
6. Navigate through the collapsible sections using only the keyboard
7. Close the rulebook and verify focus returns to the rulebook button
8. Verify `⊥` and the subscript shortcut are available in Fitch derivations
9. Open a Hurley course and verify its rulebook remains unchanged
10. Run `npm run build`

## ✅ Pre-Merge Checklist

- [x] I have performed a self-review of my own code.
- [x] I have removed all temporary `console.log`s and debuggers.
- [x] I have successfully rebased / resolved any merge conflicts with `fitch-indexed-notation`.
- [x] UI looks good on both desktop and mobile viewports.